### PR TITLE
Add static method to update a call without needing to "get" it first

### DIFF
--- a/lib/call.js
+++ b/lib/call.js
@@ -100,6 +100,18 @@ Call.create = function(client, item, callback){
 };
 
 /** Make changes to an active phone call. E.g.: transfer, hang up, answer or reject incoming calls, call recording, etc.
+ * @param client Client instance
+ * @param id Id of call
+ * @param data changed data
+ * @param callback callback function
+ * @example
+ * bandwidth.Call.update(client, "id", {state: "rejected"}, function(err){}) ;
+ * */
+Call.update = function(client, id, data, callback){
+  client.makeRequest("post", client.concatUserPath(CALL_PATH) + "/" + id, data, callback);
+};
+
+/** Make changes to an active phone call. E.g.: transfer, hang up, answer or reject incoming calls, call recording, etc.
  * @param data changed data
  * @param callback callback function
  * @example

--- a/lib/call.js
+++ b/lib/call.js
@@ -108,6 +108,12 @@ Call.create = function(client, item, callback){
  * bandwidth.Call.update(client, "id", {state: "rejected"}, function(err){}) ;
  * */
 Call.update = function(client, id, data, callback){
+  if(arguments.length === 3){
+    callback = data;
+    data = id;
+    id = client;
+    client = new Client();
+  }
   client.makeRequest("post", client.concatUserPath(CALL_PATH) + "/" + id, data, callback);
 };
 

--- a/test/call.js
+++ b/test/call.js
@@ -173,6 +173,14 @@ describe("Call", function(){
       call.update(data, done);
     });
   });
+  describe("#updateStatic", function(){
+    it("should update a call statically", function(done){
+      var data = {state: "rejected" };
+      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+      var client = helper.createClient();
+      Call.update(client, "1", data, done);
+    });
+  });
 
   describe("#playAudio", function(){
     it("should play audio", function(done){


### PR DESCRIPTION
This is a requirement for a scenario we have on RingTo.
If we have to get a call first before being able to update it, the client would hear some dead air when those actions are being completed.
