### PR TITLE
Removed global config feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,34 +38,17 @@ npm install node-bandwidth
 ```js
 var catapult = require("node-bandwidth");
 
-//Using client directly
 var client = new catapult.Client("userId", "apiToken", "apiSecret");
-
-//Or you can use default client instance.
-//Do that only once
-catapult.Client.globalOptions.apiToken = "token";
-catapult.Client.globalOptions.apiSecret = "secret";
-catapult.Client.globalOptions.userId = "userId";
 
 
 ```
 ## Usage
 
-All "static" functions support 2 ways to be called: with client instance as first arg or without client instance (default client instance will be used then)
-
 ```js
 var catapult = require("node-bandwidth");
 
-//Using client directly
 var client = new catapult.Client("userId", "apiToken", "apiSecret");
 catapult.Call.list(client, {page: 1}, function(err, calls){...});
-
-//Or you can use default client instance.
-//You should set up its global options before using of api functions.
-
-catapult.Call.list({page: 1}, function(err, calls){
-  //Default client will be used to do this calls
-});
 
 ```
 Read [Catapult Api documentation](https://catapult.inetwork.com/docs/api-docs/) for more details
@@ -76,38 +59,38 @@ Read [Catapult Api documentation](https://catapult.inetwork.com/docs/api-docs/) 
 List all calls from special number
 
 ```js
-  catapult.Call.list({from: "+19195551212"}, function(err, list) {...});
+  catapult.Call.list(client, {from: "+19195551212"}, function(err, list) {...});
 ```
 
 List all received messages
 
 ```js
-  catapult.Message.list({state: "received"}, function(err, list){...});
+  catapult.Message.list(client, {state: "received"}, function(err, list){...});
 ```
 
 Send SMS
 
 ```js
-  catapult.Message.create({from: "+19195551212", to: "+191955512142", text: "Test"}, function(err, message){...});
+  catapult.Message.create(client, {from: "+19195551212", to: "+191955512142", text: "Test"}, function(err, message){...});
 ```
 
 
 Send some SMSes
 
 ```js
-  catapult.Message.create([{from: "+19195551212", to: "+191955512142", text: "Test"}, {from: "+19195551212", to: "+191955512143", text: "Test2"}], function(err, statuses){...});
+  catapult.Message.create(client, [{from: "+19195551212", to: "+191955512142", text: "Test"}, {from: "+19195551212", to: "+191955512143", text: "Test2"}], function(err, statuses){...});
 ```
 
 Upload file 
 
 ```js
-  catapult.Media.upload("avatar.png", "/local/path/to/file.png", "image/png", function(err){...});
+  catapult.Media.upload(client, "avatar.png", "/local/path/to/file.png", "image/png", function(err){...});
 ```
 
 Make a call
 
 ```js
-  catapult.Call.create({from: "+19195551212", to: "+191955512142"}, function(err, call){...});
+  catapult.Call.create(client, {from: "+19195551212", to: "+191955512142"}, function(err, call){...});
 ```
 
 Reject incoming call
@@ -123,7 +106,7 @@ Create a gather
 
 Start a conference
 ```js
-  catapult.Conference.create({from: "+19195551212"}, function(err, conference){...});
+  catapult.Conference.create(client, {from: "+19195551212"}, function(err, conference){...});
 ```
 
 Add a member to the conference
@@ -136,30 +119,30 @@ Add a member to the conference
 Connect 2 calls to a bridge
 
 ```js
-  catapult.Bridge.create({callIds: [callId1, callId2]}, function(err, bridge){...});
+  catapult.Bridge.create(client, {callIds: [callId1, callId2]}, function(err, bridge){...});
 ```
 
 Search available local numbers to buy
 
 ```js
-  catapult.AvailableNumber.searchLocal({state: "NC", city: "Cary"}, function(err, numbers){...});
+  catapult.AvailableNumber.searchLocal(client, {state: "NC", city: "Cary"}, function(err, numbers){...});
 ```
 Get CNAM info for a number
 
 ```js
-  catapult.NumberInfo.get("+19195551212", function(err, info){...});
+  catapult.NumberInfo.get(client, "+19195551212", function(err, info){...});
 ```
 
 Buy a phone number
 
 ```js
-  catapult.PhoneNumber.create({number: "+19195551212"}, function(err, phoneNumber){...});
+  catapult.PhoneNumber.create(client, {number: "+19195551212"}, function(err, phoneNumber){...});
 ```
 
 List recordings
 
 ```js
-  catapult.Recording.list(function(err, list){...});
+  catapult.Recording.list(client, function(err, list){...});
 ```
 
 Generate Bandwidth XML

--- a/lib/account.js
+++ b/lib/account.js
@@ -1,5 +1,4 @@
 "use strict";
-var Client = require("./client");
 var ACCOUNT_PATH = "account";
 
 module.exports = {
@@ -10,10 +9,6 @@ module.exports = {
    *  bandwidth.Account.get(client, function(err, account) { ...});
    */
   get: function(client, callback){
-    if(arguments.length === 1){
-      callback = client;
-      client = new Client();
-    }
     client.makeRequest("get", client.concatUserPath(ACCOUNT_PATH), callback);
   },
   /** Get a list of the transactions made to your account
@@ -24,20 +19,11 @@ module.exports = {
    *  bandwidth.Account.getTransactions(client, function(err, transactions){ ...});
    */
   getTransactions: function(client, query, callback){
-    if(arguments.length === 1){
-      callback = client;
-      client = new Client();
-    }
     if(arguments.length === 2){
       callback = query;
-      if(client instanceof Client){
-        query = {};
-      }
-      else{
-        query = client;
-        client = new Client();
-      }
+      query = {};
     }
+
     client.makeRequest("get", client.concatUserPath(ACCOUNT_PATH) + "/transactions", query,  callback);
   }
 };

--- a/lib/application.js
+++ b/lib/application.js
@@ -20,11 +20,6 @@ function Application(){
  * bandwidth.Application.get(client, "id", function(err, app){...});
  * */
 Application.get = function(client, id, callback){
-  if(arguments.length === 2){
-    callback = id;
-    id = client;
-    client = new Client();
-  }
   client.makeRequest("get", client.concatUserPath(APPLICATION_PATH) + "/" +  id, function(err, item){
     if(err){
       return callback(err);
@@ -43,21 +38,11 @@ Application.get = function(client, id, callback){
  * bandwidth.application.list(client, function(err, apps){...});
  * */
 Application.list = function(client, query, callback){
-  if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-    query = {};
-  }
   if(arguments.length === 2){
     callback = query;
-    if(client instanceof Client){
-      query = {};
-    }
-    else{
-      query = client;
-      client = new Client();
-    }
+    query = {};
   }
+
   client.makeRequest("get", client.concatUserPath(APPLICATION_PATH), query, function(err, items){
     if(err){
       return callback(err);
@@ -80,11 +65,6 @@ Application.list = function(client, query, callback){
  * bandwidth.Application.create(client, {name: "test", incomingCallUrl: "url"}, function(err, app){});
  * */
 Application.create = function(client, item, callback){
-  if(arguments.length === 2){
-    callback = item;
-    item = client;
-    client = new Client();
-  }
   var request = client.createRequest("post", client.concatUserPath(APPLICATION_PATH));
   request.type("json").send(item).end(function(res){
     if(res.ok && res.headers.location){
@@ -109,7 +89,6 @@ Application.create = function(client, item, callback){
  * */
 Application.prototype.update = function(data, callback){
   this.client.makeRequest("post", this.client.concatUserPath(APPLICATION_PATH) + "/" + this.id,  data, callback);
-
 };
 
 /** Delete an application

--- a/lib/availableNumber.js
+++ b/lib/availableNumber.js
@@ -1,5 +1,4 @@
 "use strict";
-var Client = require("./client");
 var AVAILABLE_NUMBERS_PATH = "availableNumbers";
 module.exports = function(){
   //for compatibility only
@@ -12,20 +11,11 @@ module.exports = function(){
  * bandwidth.AvailableNumber.searchTollfree(client, {quantity: 20}, function(err, numbers){...});
  * */
 module.exports.searchTollFree = function(client, query, callback){
-  if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-  }
   if(arguments.length === 2){
     callback = query;
-    if(client instanceof Client){
-      query = {};
-    }
-    else{
-      query = client;
-      client = new Client();
-    }
+    query = {};
   }
+
   client.makeRequest("get", AVAILABLE_NUMBERS_PATH + "/tollFree", query, callback);
 };
 
@@ -37,21 +27,10 @@ module.exports.searchTollFree = function(client, query, callback){
  * bandwidth.AvailableNumber.searchLocal(client, {state: "", zip: "", areaCode: ""},, function(err, numbers){ ... });
  * */
 module.exports.searchLocal = function(client, query, callback){
-  if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-  }
   if(arguments.length === 2){
     callback = query;
-    if(client instanceof Client){
-      query = {};
-    }
-    else{
-      query = client;
-      client = new Client();
-    }
+    query = {};
   }
+
   client.makeRequest("get", AVAILABLE_NUMBERS_PATH + "/local", query, callback);
 };
-
-

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -1,6 +1,6 @@
 "use strict";
-var Client = require("./client");
 var Call = require("./call");
+var Client = require("./client");
 var BRIDGE_PATH = "bridges";
 
 function Bridge(){
@@ -13,11 +13,6 @@ function Bridge(){
  * bandwidth.Bridge.get(client, "id", function(err, bridge){...});
  * */
 Bridge.get = function(client, id, callback){
-  if(arguments.length === 2){
-    callback = id;
-    id = client;
-    client = new Client();
-  }
   client.makeRequest("get", client.concatUserPath(BRIDGE_PATH) + "/" +  id, function(err, item){
     if(err){
       return callback(err);
@@ -35,10 +30,6 @@ Bridge.get = function(client, id, callback){
  * bandwidth.Bridgw.list(client, function(err, list){});
  * */
 Bridge.list = function(client, callback){
-  if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-  }
   client.makeRequest("get", client.concatUserPath(BRIDGE_PATH), function(err, items){
     if(err){
       return callback(err);
@@ -61,11 +52,6 @@ Bridge.list = function(client, callback){
  * bandwidth.Bridge.create(client, {callIds: ["id1", "id2"]}, function(err, bridge){});
  * */
 Bridge.create = function(client, item, callback){
-  if(arguments.length === 2){
-    callback = item;
-    item = client;
-    client = new Client();
-  }
   var request = client.createRequest("post", client.concatUserPath(BRIDGE_PATH));
   request.type("json").send(item).end(function(res){
     if(res.ok && res.headers.location){

--- a/lib/call.js
+++ b/lib/call.js
@@ -18,11 +18,6 @@ function Call(){
  * bandwidth.Client.get(client, "id", function(err, call){});
  * */
 Call.get = function(client, id, callback){
-  if(arguments.length === 2){
-    callback = id;
-    id = client;
-    client = new Client();
-  }
   client.makeRequest("get", client.concatUserPath(CALL_PATH) + "/" +  id, function(err, item){
     if(err){
       return callback(err);
@@ -43,19 +38,9 @@ Call.get = function(client, id, callback){
 Call.list = function(client, query, callback){
   if(arguments.length === 2){
     callback = query;
-    if(client instanceof Client){
-      query = {};
-    }
-    else{
-      query = client;
-      client = new Client();
-    }
-  }
-  else if(arguments.length === 1){
-    callback = client;
-    client = new Client();
     query = {};
   }
+
   client.makeRequest("get", client.concatUserPath(CALL_PATH), query, function(err, items){
     if(err){
       return callback(err);
@@ -78,11 +63,6 @@ Call.list = function(client, query, callback){
  * bandwidth.Call.create(client, {from: "", to: ""}, function(err, call){});
  * */
 Call.create = function(client, item, callback){
-  if(arguments.length === 2){
-    callback = item;
-    item = client;
-    client = new Client();
-  }
   var request = client.createRequest("post", client.concatUserPath(CALL_PATH));
   request.type("json").send(item).end(function(res){
     if(res.ok && res.headers.location){

--- a/lib/client.js
+++ b/lib/client.js
@@ -7,9 +7,10 @@ function Client(userId, apiToken, apiSecret, options){
   if(!(this instanceof Client)){
     return new Client(userId, apiToken, apiSecret, options);
   }
+
   if(typeof options !== "object" && arguments.length === 4){
     //compability with previous version of lib
-    var opts = {apiEndPoint: (userId)?("https://" + userId):null};
+    var opts = { apiEndPoint: (userId)?("https://" + userId):null };
     this.host = userId;
     userId = apiToken;
     this.userId = userId;
@@ -19,26 +20,25 @@ function Client(userId, apiToken, apiSecret, options){
     this.secret = apiSecret;
     options = opts;
   }
+
   if(arguments.length === 1){
     options = arguments[0];
     userId = options.userId;
   }
+
+  var defaults = {
+    apiEndPoint: "https://api.catapult.inetwork.com",
+    apiVersion: "v1"
+  };
+
   options = options || {};
-  if(!userId){
-    userId = Client.globalOptions.userId;
-  }
-  if(!apiToken){
-    apiToken = options.apiToken || Client.globalOptions.apiToken;
-  }
-  if(!apiSecret){
-    apiSecret = options.apiSecret || Client.globalOptions.apiSecret;
-  }
-  if(!options.apiEndPoint){
-    options.apiEndPoint = Client.globalOptions.apiEndPoint;
-  }
-  if(!options.apiVersion){
-    options.apiVersion = Client.globalOptions.apiVersion;
-  }
+
+  apiToken = apiToken || options.apiToken;
+  apiSecret = apiSecret || options.apiSecret;
+  userId = userId || options.userId || defaults.userId;
+  options.apiEndPoint = options.apiEndPoint || defaults.apiEndPoint;
+  options.apiVersion = options.apiVersion || defaults.apiVersion;
+
   this.prepareRequest = function(req){
     return req.auth(apiToken, apiSecret).accept("json");
   };
@@ -51,15 +51,6 @@ function Client(userId, apiToken, apiSecret, options){
     return options.apiEndPoint + "/" + options.apiVersion + ((path[0] == "/")?path:("/" + path));
   };
 }
-
-/** global options (used when constructor called without params) */
-Client.globalOptions = {
-  apiEndPoint: "https://api.catapult.inetwork.com",
-  apiVersion: "v1",
-  apiToken: "",
-  apiSecret: "",
-  userId: ""
-};
 
 /** Extract id from location header */
 Client.getIdFromLocationHeader = function(location, callback){

--- a/lib/conference.js
+++ b/lib/conference.js
@@ -14,11 +14,6 @@ function Conference(){
  * bandwidth.Conference.get(client, "id", function(err, conference){});
  * */
 Conference.get = function(client, id, callback){
-  if(arguments.length === 2){
-    callback = id;
-    id = client;
-    client = new Client();
-  }
   client.makeRequest("get", client.concatUserPath(CONFERENCE_PATH) + "/" +  id, function(err, item){
     if(err){
       return callback(err);
@@ -36,11 +31,6 @@ Conference.get = function(client, id, callback){
  * @example
  * bandwidth.Conference.create(client, {from: "number"}, function(err, conference){});*/
 Conference.create = function(client, item, callback){
-  if(arguments.length === 2){
-    callback = item;
-    item = client;
-    client = new Client();
-  }
   var request = client.createRequest("post", client.concatUserPath(CONFERENCE_PATH));
   request.type("json").send(item).end(function(res){
     if(res.ok && res.headers.location){

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -13,10 +13,6 @@ function Domain(){
  * bandwidth.Domain.list(client,  function(err, domains){});
  * */
 Domain.list = function(client, callback){
-  if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-  }
   client.makeRequest("get", client.concatUserPath(DOMAIN_PATH), function(err, items){
     if(err){
       return callback(err);
@@ -37,11 +33,6 @@ Domain.list = function(client, callback){
  * @example
  * bandwidth.Domain.create(client, {name: "domain1"}, function(err, domain){});*/
 Domain.create = function(client, item, callback){
-  if(arguments.length === 2){
-    callback = item;
-    item = client;
-    client = new Client();
-  }
   var request = client.createRequest("post", client.concatUserPath(DOMAIN_PATH));
   request.type("json").send(item).end(function(res){
     if(res.ok && res.headers.location){

--- a/lib/endPoint.js
+++ b/lib/endPoint.js
@@ -1,5 +1,4 @@
 "use strict";
-var Client = require("./client");
 var DOMAIN_PATH = "domains";
 var ENDPOINT_PATH = "endpoints";
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,5 +1,4 @@
 "use strict";
-var Client = require("./client");
 var ERROR_PATH = "errors";
 
 module.exports = {
@@ -11,11 +10,6 @@ module.exports = {
    *  bandwidth.Error.get(client, "id", function(err, errorData){});
    * */
   get: function(client, id, callback){
-    if(arguments.length === 2){
-      callback = id;
-      id = client;
-      client = new Client();
-    }
     client.makeRequest("get", client.concatUserPath(ERROR_PATH) + "/" + id, callback);
   },
   /** Gets all the user errors for a user
@@ -26,20 +20,11 @@ module.exports = {
    * bandwidth.Error.list(client, function(err, list){});
    * */
   list: function(client, query, callback){
-    if(arguments.length === 1){
-      callback = client;
-      client = new Client();
-    }
     if(arguments.length === 2){
       callback = query;
-      if(client instanceof Client){
-        query = {};
-      }
-      else{
-        query = client;
-        client = new Client();
-      }
+      query = {};
     }
+
     client.makeRequest("get", client.concatUserPath(ERROR_PATH), query, callback);
   }
 };

--- a/lib/media.js
+++ b/lib/media.js
@@ -1,5 +1,4 @@
 "use strict";
-var Client = require("./client");
 var fs = require("fs");
 var errors = require("./errors");
 var MEDIA_PATH = "media";
@@ -36,20 +35,11 @@ module.exports = {
    * bandwidth.Media.list(client, function(err, list){});
    * */
   list: function(client, query, callback){
-    if(arguments.length === 1){
-      callback = client;
-      client = new Client();
-    }
-    else if(arguments.length === 2){
+    if(arguments.length === 2){
       callback = query;
-      if(client instanceof Client){
-        query = {};
-      }
-      else{
-        query = client;
-        client = new Client();
-      }
+      query = {};
     }
+
     client.makeRequest("get", client.concatUserPath(MEDIA_PATH), query, callback);
   },
 
@@ -62,25 +52,11 @@ module.exports = {
    * bandwidth.Media.upload(client, "file.pdf", stream, "application/pdf", function(err){});
    * */
   upload: function(client, name, data, mediaType, callback){
-    if(arguments.length === 3){
-      callback = data;
-      data = name;
-      name = client;
-      client = new Client();
+    if(arguments.length === 4){
+      callback = mediaType;
       mediaType = null;
     }
-    else if(arguments.length === 4){
-      callback = mediaType;
-      if(client instanceof Client){
-        mediaType = null;
-      }
-      else{
-        mediaType = data;
-        data = name;
-        name = client;
-        client = new Client();
-      }
-    }
+
     var request = client.createRequest("put", client.concatUserPath(MEDIA_PATH) + "/" + encodeURIComponent(name));
     sendFile(request, data, mediaType, function(res){
       client.checkResponse(res, callback);
@@ -96,15 +72,9 @@ module.exports = {
    * */
   download: function(client, name, destination){
     if(arguments.length <= 2){
-      if(client instanceof Client){
-        destination = null;
-      }
-      else{
-        destination = name;
-        name = client;
-        client = new Client();
-      }
+      destination = null;
     }
+
     var request = client.createRequest("get", client.concatUserPath(MEDIA_PATH) + "/" + encodeURIComponent(name));
     if(destination){
       var stream = null;
@@ -128,11 +98,6 @@ module.exports = {
    * bandwidth.delete(client, "file1.pdf", function(err){});
    * */
   delete: function(client, name, callback){
-    if(arguments.length === 2){
-      callback = name;
-      name = client;
-      client = new Client();
-    }
     client.makeRequest("del", client.concatUserPath(MEDIA_PATH) + "/" + encodeURIComponent(name), callback);
   },
 
@@ -145,11 +110,6 @@ module.exports = {
    * bandwidth.Media.getInfo(client, "file1.wav", function(err, res){});
    * */
   getInfo: function(client, name, callback){
-    if(arguments.length === 2){
-      callback = name;
-      name = client;
-      client = new Client();
-    }
     var request = client.createRequest("head", client.concatUserPath(MEDIA_PATH) + "/" + encodeURIComponent(name));
     request.end( function (err, res){
       if(res.ok){

--- a/lib/message.js
+++ b/lib/message.js
@@ -19,11 +19,6 @@ function Message(){
  * bandwidth.Message.get(client, "id", function(err, message){});
  * */
 Message.get = function(client, id, callback){
-  if(arguments.length === 2){
-    callback = id;
-    id = client;
-    client = new Client();
-  }
   client.makeRequest("get", client.concatUserPath(MESSAGE_PATH) + "/" +  id, function(err, item){
     if(err){
       return callback(err);
@@ -44,18 +39,9 @@ Message.get = function(client, id, callback){
 Message.list = function(client, query, callback){
   if(arguments.length === 2){
     callback = query;
-    if(client instanceof Client){
-      query = {};
-    }
-    else{
-      query = client;
-      client = new Client();
-    }
+    query = {};
   }
-  else if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-  }
+
   client.makeRequest("get", client.concatUserPath(MESSAGE_PATH), query, function(err, items){
     if(err){
       return callback(err);
@@ -79,11 +65,6 @@ Message.list = function(client, query, callback){
  * bandwidth.Message.create(client, [{from: "", to: "", text: ""}], function(err, statuses){});
  * */
 Message.create = function(client, item, callback){
-  if(arguments.length === 2){
-    callback = item;
-    item = client;
-    client = new Client();
-  }
   var isList = Array.isArray(item);
   var request = client.createRequest("post", client.concatUserPath(MESSAGE_PATH));
   request.type("json").send(item).end(function(res){

--- a/lib/numberInfo.js
+++ b/lib/numberInfo.js
@@ -1,5 +1,4 @@
 "use strict";
-var Client = require("./client");
 var NUMBER_INFO_PATH = "phoneNumbers/numberInfo";
 
 module.exports = {
@@ -11,11 +10,6 @@ module.exports = {
    * bandwidth.NumberInfo.get(client, "number", function(err, info){});
    * */
   get: function(client, number, callback){
-    if(arguments.length === 2){
-      callback = number;
-      number = client;
-      client = new Client();
-    }
     client.makeRequest("get", NUMBER_INFO_PATH + "/" + encodeURIComponent(number), callback);
   }
 };

--- a/lib/phoneNumber.js
+++ b/lib/phoneNumber.js
@@ -19,11 +19,6 @@ function PhoneNumber(){
  * bandwidth.PhoneNumber.get(client, "id", function(err, number){});
  * */
 PhoneNumber.get = function(client, id, callback){
-  if(arguments.length === 2){
-    callback = id;
-    id = client;
-    client = new Client();
-  }
   client.makeRequest("get", client.concatUserPath(PHONE_NUMBER_PATH) + "/" +  id, function(err, item){
     if(err){
       return callback(err);
@@ -44,18 +39,9 @@ PhoneNumber.get = function(client, id, callback){
 PhoneNumber.list = function(client, query, callback){
   if(arguments.length === 2){
     callback = query;
-    if(client instanceof Client){
-      query = {};
-    }
-    else{
-      query = client;
-      client = new Client();
-    }
+    query = {};
   }
-  else if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-  }
+
   client.makeRequest("get", client.concatUserPath(PHONE_NUMBER_PATH), query, function(err, items){
     if(err){
       return callback(err);
@@ -78,11 +64,6 @@ PhoneNumber.list = function(client, query, callback){
  * bandwidth.PhoneNumber.create(client, {number: "number"}, function(err, number){});
  * */
 PhoneNumber.create = function(client, item, callback){
-  if(arguments.length === 2){
-    callback = item;
-    item = client;
-    client = new Client();
-  }
   var request = client.createRequest("post", client.concatUserPath(PHONE_NUMBER_PATH));
   request.type("json").send(item).end(function(res){
     if(res.ok && res.headers.location){

--- a/lib/recording.js
+++ b/lib/recording.js
@@ -13,11 +13,6 @@ function Recording(){
  * bandwidth.Recording.get(client, "id", function(err, recording){});
  * */
 Recording.get = function(client, id, callback){
-  if(arguments.length === 2){
-    callback = id;
-    id = client;
-    client = new Client();
-  }
   client.makeRequest("get", client.concatUserPath(RECORDING_PATH) + "/" +  id, function(err, item){
     if(err){
       return callback(err);
@@ -38,18 +33,9 @@ Recording.get = function(client, id, callback){
 Recording.list = function(client, query, callback){
   if(arguments.length === 2){
     callback = query;
-    if(client instanceof Client){
-      query = {};
-    }
-    else{
-      query = client;
-      client = new Client();
-    }
+    query = {};
   }
-  else if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-  }
+
   client.makeRequest("get", client.concatUserPath(RECORDING_PATH), query, function(err, items){
     if(err){
       return callback(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-bandwidth",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "description": "NodeJs Client library for Catapult API",
   "main": "index.js",
   "scripts": {

--- a/test/account.js
+++ b/test/account.js
@@ -6,7 +6,6 @@ var Account = lib.Account;
 describe("Account", function(){
   before(function(){
     nock.disableNetConnect();
-    helper.setupGlobalOptions();
   });
   after(function(){
     nock.cleanAll();
@@ -20,16 +19,6 @@ describe("Account", function(){
     it("should return account info", function(done){
       helper.nock().get("/v1/users/FakeUserId/account").reply(200, item);
       Account.get(helper.createClient(),function(err, i){
-        if(err){
-          return done(err);
-        }
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should return account info (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/account").reply(200, item);
-      Account.get(function(err, i){
         if(err){
           return done(err);
         }
@@ -53,29 +42,9 @@ describe("Account", function(){
         done();
       });
     });
-    it("should return transactions (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/account/transactions?page=1").reply(200, items);
-      Account.getTransactions({page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
     it("should return transactions (without query)", function(done){
       helper.nock().get("/v1/users/FakeUserId/account/transactions").reply(200, items);
       Account.getTransactions(helper.createClient(), function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return transactions (with default client, without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/account/transactions").reply(200, items);
-      Account.getTransactions(function(err, list){
         if(err){
           return done(err);
         }

--- a/test/application.js
+++ b/test/application.js
@@ -6,7 +6,6 @@ var Application = lib.Application;
 describe("Application", function(){
   before(function(){
     nock.disableNetConnect();
-    helper.setupGlobalOptions();
   });
   after(function(){
     nock.cleanAll();
@@ -34,31 +33,9 @@ describe("Application", function(){
         done();
       });
     });
-    it("should return list of applications (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/applications?page=1").reply(200, items);
-      Application.list({page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
     it("should return list of applications (without query)", function(done){
       helper.nock().get("/v1/users/FakeUserId/applications").reply(200, items);
       Application.list(helper.createClient(), function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of applications (with default client, without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/applications").reply(200, items);
-      Application.list(function(err, list){
         if(err){
           return done(err);
         }
@@ -94,17 +71,6 @@ describe("Application", function(){
         done();
       });
     });
-    it("should return an application (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/applications/1").reply(200, item);
-      Application.get("1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
     it("should fail on remote request failing", function(done){
       helper.nock().get("/v1/users/FakeUserId/applications/1").reply(500);
       Application.get(helper.createClient(), "1", function(err){
@@ -129,18 +95,6 @@ describe("Application", function(){
       helper.nock().post("/v1/users/FakeUserId/applications", data).reply(201, "", {"Location": "/v1/users/FakeUserId/applications/1"});
       helper.nock().get("/v1/users/FakeUserId/applications/1").reply(200, item);
       Application.create(helper.createClient(), data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should create an application (with default client)", function(done){
-      helper.nock().post("/v1/users/FakeUserId/applications", data).reply(201, "", {"Location": "/v1/users/FakeUserId/applications/1"});
-      helper.nock().get("/v1/users/FakeUserId/applications/1").reply(200, item);
-      Application.create(data,  function(err, i){
         if(err){
           return done(err);
         }

--- a/test/availableNumber.js
+++ b/test/availableNumber.js
@@ -25,7 +25,6 @@ describe("AvailableNumber", function(){
   }];
   before(function(){
     nock.disableNetConnect();
-    helper.setupGlobalOptions();
   });
   after(function(){
     nock.cleanAll();
@@ -42,29 +41,9 @@ describe("AvailableNumber", function(){
         done();
       });
     });
-    it("should return numbers (with default client)", function(done){
-      helper.nock().get("/v1/availableNumbers/tollFree?criteria1=1").reply(200, items);
-      AvailableNumber.searchTollFree({criteria1: 1},function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
     it("should return numbers (without query)", function(done){
       helper.nock().get("/v1/availableNumbers/tollFree").reply(200, items);
       AvailableNumber.searchTollFree(helper.createClient(), function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return numbers (with default client, without query)", function(done){
-      helper.nock().get("/v1/availableNumbers/tollFree").reply(200, items);
-      AvailableNumber.searchTollFree(function(err, list){
         if(err){
           return done(err);
         }
@@ -84,29 +63,9 @@ describe("AvailableNumber", function(){
         done();
       });
     });
-    it("should return numbers (with default client)", function(done){
-      helper.nock().get("/v1/availableNumbers/local?criteria1=1").reply(200, items);
-      AvailableNumber.searchLocal({criteria1: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
     it("should return numbers (without query)", function(done){
       helper.nock().get("/v1/availableNumbers/local").reply(200, items);
       AvailableNumber.searchLocal(helper.createClient(), function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return numbers (with default client, without query)", function(done){
-      helper.nock().get("/v1/availableNumbers/local").reply(200, items);
-      AvailableNumber.searchLocal(function(err, list){
         if(err){
           return done(err);
         }

--- a/test/bridge.js
+++ b/test/bridge.js
@@ -6,7 +6,6 @@ var Bridge = lib.Bridge;
 describe("Bridge", function(){
   before(function(){
     nock.disableNetConnect();
-    helper.setupGlobalOptions();
   });
   after(function(){
     nock.cleanAll();
@@ -24,17 +23,6 @@ describe("Bridge", function(){
     it("should return list of bridges", function(done){
       helper.nock().get("/v1/users/FakeUserId/bridges").reply(200, items);
       Bridge.list(helper.createClient(),  function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of bridges (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/bridges").reply(200, items);
-      Bridge.list(function(err, list){
         if(err){
           return done(err);
         }
@@ -69,17 +57,6 @@ describe("Bridge", function(){
         done();
       });
     });
-    it("should return a bridge (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/bridges/1").reply(200, item);
-      Bridge.get("1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
     it("should fail on remote request failing", function(done){
       helper.nock().get("/v1/users/FakeUserId/bridges/1").reply(500);
       Bridge.get(helper.createClient(), "1", function(err){
@@ -102,18 +79,6 @@ describe("Bridge", function(){
       helper.nock().post("/v1/users/FakeUserId/bridges", data).reply(201, "", {"Location": "/v1/users/FakeUserId/bridges/1"});
       helper.nock().get("/v1/users/FakeUserId/bridges/1").reply(200, item);
       Bridge.create(helper.createClient(), data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should create a bridge (with default client)", function(done){
-      helper.nock().post("/v1/users/FakeUserId/bridges", data).reply(201, "", {"Location": "/v1/users/FakeUserId/bridges/1"});
-      helper.nock().get("/v1/users/FakeUserId/bridges/1").reply(200, item);
-      Bridge.create(data,  function(err, i){
         if(err){
           return done(err);
         }

--- a/test/call.js
+++ b/test/call.js
@@ -6,7 +6,6 @@ var Call = lib.Call
 describe("Call", function(){
   before(function(){
     nock.disableNetConnect();
-    helper.setupGlobalOptions();
   });
   after(function(){
     nock.cleanAll();
@@ -36,31 +35,9 @@ describe("Call", function(){
         done();
       });
     });
-    it("should return list of calls (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls?page=1").reply(200, items);
-      Call.list({page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
     it("should return list of calls (without query)", function(done){
       helper.nock().get("/v1/users/FakeUserId/calls").reply(200, items);
       Call.list(helper.createClient(), function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of calls (with default client, without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls").reply(200, items);
-      Call.list(function(err, list){
         if(err){
           return done(err);
         }
@@ -97,17 +74,6 @@ describe("Call", function(){
         done();
       });
     });
-    it("should return a call (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, item);
-      Call.get("1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
     it("should fail on remote request failing", function(done){
       helper.nock().get("/v1/users/FakeUserId/calls/1").reply(500);
       Call.get(helper.createClient(), "1", function(err){
@@ -133,18 +99,6 @@ describe("Call", function(){
       helper.nock().post("/v1/users/FakeUserId/calls", data).reply(201, "", {"Location": "/v1/users/FakeUserId/calls/1"});
       helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, item);
       Call.create(helper.createClient(), data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should create a  call (with default client)", function(done){
-      helper.nock().post("/v1/users/FakeUserId/calls", data).reply(201, "", {"Location": "/v1/users/FakeUserId/calls/1"});
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, item);
-      Call.create(data,  function(err, i){
         if(err){
           return done(err);
         }

--- a/test/client.js
+++ b/test/client.js
@@ -11,9 +11,11 @@ describe("client tests", function(){
   });
   describe("#constructor", function(){
     it("should create client instance", function(){
-      var client = new Client();
-      client.should.be.instanceof(Client);
-      Client().should.be.instanceof(Client);
+      (new Client("FakeUserId", "FakeApiToken", "FakeApiSecret")).should.be.instanceof(Client);
+    });
+
+    it("should return an instance if invoked without new", function () {
+      Client("FakeUserId", "FakeApiToken", "FakeApiSecret").should.be.instanceof(Client);
     });
   });
   describe("#makeRequest", function(){
@@ -120,7 +122,7 @@ describe("client tests", function(){
   });
   describe("#concatUserPath", function(){
     it("should return formatted url", function(){
-      var client = new Client({userId: "userId"});
+      var client = new Client({userId: "userId", apiToken: "token", apiSecret: "secret"});
       client.concatUserPath("test").should.equal("/users/userId/test");
       client.concatUserPath("/test1").should.equal("/users/userId/test1");
     });

--- a/test/conference.js
+++ b/test/conference.js
@@ -6,7 +6,6 @@ var Conference = lib.Conference;
 describe("Conference", function(){
   before(function(){
     nock.disableNetConnect();
-    helper.setupGlobalOptions();
   });
   after(function(){
     nock.cleanAll();
@@ -21,17 +20,6 @@ describe("Conference", function(){
     it("should return a conference", function(done){
       helper.nock().get("/v1/users/FakeUserId/conferences/1").reply(200, item);
       Conference.get(helper.createClient(), "1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should return a conference (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/conferences/1").reply(200, item);
-      Conference.get("1", function(err, i){
         if(err){
           return done(err);
         }
@@ -64,18 +52,6 @@ describe("Conference", function(){
       helper.nock().post("/v1/users/FakeUserId/conferences", data).reply(201, "", {"Location": "/v1/users/FakeUserId/conferences/1"});
       helper.nock().get("/v1/users/FakeUserId/conferences/1").reply(200, item);
       Conference.create(helper.createClient(), data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should create a conference (with default client)", function(done){
-      helper.nock().post("/v1/users/FakeUserId/conferences", data).reply(201, "", {"Location": "/v1/users/FakeUserId/conferences/1"});
-      helper.nock().get("/v1/users/FakeUserId/conferences/1").reply(200, item);
-      Conference.create(data,  function(err, i){
         if(err){
           return done(err);
         }

--- a/test/conferenceMember.js
+++ b/test/conferenceMember.js
@@ -6,7 +6,6 @@ var ConferenceMember = lib.ConferenceMember;
 describe("ConferenceMember", function(){
   before(function(){
     nock.disableNetConnect();
-    helper.setupGlobalOptions();
   });
   after(function(){
     nock.cleanAll();

--- a/test/domain.js
+++ b/test/domain.js
@@ -7,7 +7,6 @@ var Domain = lib.Domain;
 describe("Domain", function(){
   before(function(){
     nock.disableNetConnect();
-    helper.setupGlobalOptions();
   });
   after(function(){
     nock.cleanAll();
@@ -27,17 +26,6 @@ describe("Domain", function(){
     it("should return domains", function(done){
       helper.nock().get("/v1/users/FakeUserId/domains").reply(200, items);
       Domain.list(helper.createClient(), function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){ delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return a domain (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/domains").reply(200, items);
-      Domain.list(function(err, list){
         if(err){
           return done(err);
         }
@@ -70,18 +58,6 @@ describe("Domain", function(){
       helper.nock().post("/v1/users/FakeUserId/domains", data).reply(201, "", {"Location": "/v1/users/FakeUserId/domains/1"});
       helper.nock().get("/v1/users/FakeUserId/domains/1").reply(200, item);
       Domain.create(helper.createClient(), data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should create a domain (with default client)", function(done){
-      helper.nock().post("/v1/users/FakeUserId/domains", data).reply(201, "", {"Location": "/v1/users/FakeUserId/domains/1"});
-      helper.nock().get("/v1/users/FakeUserId/domains/1").reply(200, item);
-      Domain.create(data,  function(err, i){
         if(err){
           return done(err);
         }

--- a/test/endPoint.js
+++ b/test/endPoint.js
@@ -7,7 +7,6 @@ var EndPoint = lib.EndPoint;
 describe("EndPoint", function(){
   before(function(){
     nock.disableNetConnect();
-    helper.setupGlobalOptions();
   });
   after(function(){
     nock.cleanAll();

--- a/test/error.js
+++ b/test/error.js
@@ -6,7 +6,6 @@ var Error = lib.Error;
 describe("Error", function(){
   before(function(){
     nock.disableNetConnect();
-    helper.setupGlobalOptions();
   });
   after(function(){
     nock.cleanAll();
@@ -21,16 +20,6 @@ describe("Error", function(){
     it("should return error info", function(done){
       helper.nock().get("/v1/users/FakeUserId/errors/100").reply(200, item);
       Error.get(helper.createClient(), "100", function(err, i){
-        if(err){
-          return done(err);
-        }
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should return error info (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/errors/100").reply(200, item);
-      Error.get("100", function(err, i){
         if(err){
           return done(err);
         }
@@ -54,29 +43,9 @@ describe("Error", function(){
         done();
       });
     });
-    it("should return transactions (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/errors?page=1").reply(200, items);
-      Error.list({page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
     it("should return transactions (without query)", function(done){
       helper.nock().get("/v1/users/FakeUserId/errors").reply(200, items);
       Error.list(helper.createClient(), function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return transactions (with default client, without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/errors").reply(200, items);
-      Error.list(function(err, list){
         if(err){
           return done(err);
         }

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,12 +1,6 @@
 var Client = require("../").Client;
 var nock = require("nock");
 module.exports = {
-  setupGlobalOptions: function(){
-    Client.globalOptions.userId = "FakeUserId";
-    Client.globalOptions.apiToken = "FakeApiToken";
-    Client.globalOptions.apiSecret = "FakeApiSecret";
-  },
-
   createClient: function(){
     return new Client("FakeUserId", "FakeApiToken", "FakeApiSecret");
   },

--- a/test/media.js
+++ b/test/media.js
@@ -11,7 +11,6 @@ var tmpFile = path.join(os.tmpdir(), "dest.txt");
 describe("Media", function(){
   before(function(){
     nock.disableNetConnect();
-    helper.setupGlobalOptions();
   });
   after(function(){
     nock.cleanAll();
@@ -32,29 +31,9 @@ describe("Media", function(){
         done();
       });
     });
-    it("should return account info (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/media?page=1").reply(200, items);
-      Media.list({page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
     it("should return list of files (without query)", function(done){
       helper.nock().get("/v1/users/FakeUserId/media").reply(200, items);
       Media.list(helper.createClient(), function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return account info (with default client, without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/media").reply(200, items);
-      Media.list(function(err, list){
         if(err){
           return done(err);
         }
@@ -68,10 +47,6 @@ describe("Media", function(){
       helper.nock().delete("/v1/users/FakeUserId/media/fileName").reply(200);
       Media.delete(helper.createClient(), "fileName", done);
     });
-    it("should delete file from the server (with default client)", function(done){
-      helper.nock().delete("/v1/users/FakeUserId/media/fileName").reply(200);
-      Media.delete("fileName", done);
-    });
   });
   describe("#getInfo", function(){
     it("should get info on file from server", function(done){
@@ -84,19 +59,9 @@ describe("Media", function(){
         done();
       });
     });
-    it("should get info on file from server (with default client)", function(done){
-      helper.nock().head("/v1/users/FakeUserId/media/file1").reply(200, "OK", {'Content-Length': 100});
-      Media.getInfo("file1", function(err, result){
-        if (err){
-          return done(err);
-        }
-        result.contentLength.should.eql(100);
-        done();
-      });
-    });
     it("should error on getting info on non existing file", function(done){
         helper.nock().head("/v1/users/FakeUserId/media/nonexistingfile").reply(404);
-        Media.getInfo("nonexistingfile", function(err, result){
+        Media.getInfo(helper.createClient(), "nonexistingfile", function(err, result){
           err.httpStatus.should.eql(404);
           done();
         });
@@ -122,34 +87,9 @@ describe("Media", function(){
         });
       });
     });
-    it("should download file to destination file (with default client)", function(done){
-      var stream = Media.download("fileName", tmpFile);
-      stream.on("finish", function(){
-        fs.readFile(tmpFile, "utf8", function(err, text){
-          if(err){
-            done(err);
-          }
-          text.should.equal("12345");
-          done();
-        });
-      });
-    });
     it("should download file to destination stream", function(done){
       var outputStream = fs.createWriteStream(tmpFile);
       var stream = Media.download(helper.createClient(), "fileName", outputStream);
-      stream.on("finish", function(){
-        fs.readFile(tmpFile, "utf8", function(err, text){
-          if(err){
-            done(err);
-          }
-          text.should.equal("12345");
-          done();
-        });
-      });
-    });
-    it("should download file to destination stream (with default client)", function(done){
-      var outputStream = fs.createWriteStream(tmpFile);
-      var stream = Media.download("fileName", outputStream);
       stream.on("finish", function(){
         fs.readFile(tmpFile, "utf8", function(err, text){
           if(err){
@@ -173,19 +113,6 @@ describe("Media", function(){
         });
       });
     });
-    it("should allow access to request (with default client)", function(done){
-      var outputStream = fs.createWriteStream(tmpFile);
-      var stream = Media.download("fileName").pipe(outputStream);
-      stream.on("finish", function(){
-        fs.readFile(tmpFile, "utf8", function(err, text){
-          if(err){
-            done(err);
-          }
-          text.should.equal("12345");
-          done();
-        });
-      });
-    });
   });
   describe("#upload", function(){
     before(function(done){
@@ -197,16 +124,9 @@ describe("Media", function(){
     it("should upload file to the server", function(done){
       Media.upload(helper.createClient(), "fileName", tmpFile, "text/plain", done);
     });
-    it("should upload file to the server (with default client)", function(done){
-      Media.upload("fileName", tmpFile, "text/plain", done);
-    });
     it("should upload file to the server (without media type)", function(done){
       helper.nock().put("/v1/users/FakeUserId/media/fileName", "12345", {"Content-Type": "application/octet-stream"}).reply(200);
       Media.upload(helper.createClient(), "fileName", tmpFile, done);
-    });
-    it("should upload file to the server (with default client, without media type)", function(done){
-      helper.nock().put("/v1/users/FakeUserId/media/fileName", "12345", {"Content-Type": "application/octet-stream"}).reply(200);
-      Media.upload("fileName", tmpFile, done);
     });
     it("should upload stream to the server", function(done){
       Media.upload(helper.createClient(), "fileName", fs.createReadStream(tmpFile), "text/plain", done);

--- a/test/message.js
+++ b/test/message.js
@@ -6,7 +6,6 @@ var Message = lib.Message;
 describe("Message", function(){
   before(function(){
     nock.disableNetConnect();
-    helper.setupGlobalOptions();
   });
   after(function(){
     nock.cleanAll();
@@ -37,31 +36,9 @@ describe("Message", function(){
         done();
       });
     });
-    it("should return list of messages (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/messages?page=1").reply(200, items);
-      Message.list({page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
     it("should return list of messages (without query)", function(done){
       helper.nock().get("/v1/users/FakeUserId/messages").reply(200, items);
       Message.list(helper.createClient(),  function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of messages (with default client, without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/messages").reply(200, items);
-      Message.list(function(err, list){
         if(err){
           return done(err);
         }
@@ -90,17 +67,6 @@ describe("Message", function(){
     it("should return a message", function(done){
       helper.nock().get("/v1/users/FakeUserId/messages/1").reply(200, item);
       Message.get(helper.createClient(), "1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should return a message (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/messages/1").reply(200, item);
-      Message.get("1", function(err, i){
         if(err){
           return done(err);
         }
@@ -151,30 +117,6 @@ describe("Message", function(){
           return done(err);
         }
         statuses[0].error.message.should.equal("Error");
-        statuses[1].id.should.equal("1")
-        done();
-      });
-    });
-    it("should create a message (with default client)", function(done){
-      helper.nock().post("/v1/users/FakeUserId/messages", data).reply(201, "", {"Location": "/v1/users/FakeUserId/messages/1"});
-      helper.nock().get("/v1/users/FakeUserId/messages/1").reply(200, item);
-      Message.create(data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should create list of messages (with default client)", function(done){
-      var data = [{from: "from1", to: "to1", text: "text1"}, {from: "from2", to: "to2", text: "text2"}];
-      helper.nock().post("/v1/users/FakeUserId/messages", data).reply(200, [{result: "accepted"}, {result: "accepted", location: "/v1/users/FakeUserId/messages/1"}]);
-      Message.create( data,  function(err, statuses){
-        if(err){
-          return done(err);
-        }
-        statuses[0].error.should.be.ok;
         statuses[1].id.should.equal("1")
         done();
       });

--- a/test/numberInfo.js
+++ b/test/numberInfo.js
@@ -6,7 +6,6 @@ var NumberInfo = lib.NumberInfo;
 describe("NumberInfo", function(){
   before(function(){
     nock.disableNetConnect();
-    helper.setupGlobalOptions();
   });
   after(function(){
     nock.cleanAll();
@@ -19,16 +18,6 @@ describe("NumberInfo", function(){
     it("should return number info", function(done){
       helper.nock().get("/v1/phoneNumbers/numberInfo/11111").reply(200, item);
       NumberInfo.get(helper.createClient(), "11111", function(err, i){
-        if(err){
-          return done(err);
-        }
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should return numberInfo info (with default client)", function(done){
-      helper.nock().get("/v1/phoneNumbers/numberInfo/11111").reply(200, item);
-      NumberInfo.get("11111", function(err, i){
         if(err){
           return done(err);
         }

--- a/test/phoneNumber.js
+++ b/test/phoneNumber.js
@@ -6,7 +6,6 @@ var PhoneNumber = lib.PhoneNumber;
 describe("PhoneNumber", function(){
   before(function(){
     nock.disableNetConnect();
-    helper.setupGlobalOptions();
   });
   after(function(){
     nock.cleanAll();
@@ -34,31 +33,9 @@ describe("PhoneNumber", function(){
         done();
       });
     });
-    it("should return list of phoneNumbers (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers?page=1").reply(200, items);
-      PhoneNumber.list({page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
     it("should return list of phoneNumbers (without query)", function(done){
       helper.nock().get("/v1/users/FakeUserId/phoneNumbers").reply(200, items);
       PhoneNumber.list(helper.createClient(),  function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of phoneNumbers (with default client, without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers").reply(200, items);
-      PhoneNumber.list(function(err, list){
         if(err){
           return done(err);
         }
@@ -94,17 +71,6 @@ describe("PhoneNumber", function(){
         done();
       });
     });
-    it("should return a phoneNumber (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(200, item);
-      PhoneNumber.get("1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
     it("should fail on remote request failing", function(done){
       helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(500);
       PhoneNumber.get(helper.createClient(), "1", function(err){
@@ -128,18 +94,6 @@ describe("PhoneNumber", function(){
       helper.nock().post("/v1/users/FakeUserId/phoneNumbers", data).reply(201, "", {"Location": "/v1/users/FakeUserId/phoneNumbers/1"});
       helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(200, item);
       PhoneNumber.create(helper.createClient(), data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should create a phoneNumber (with default client)", function(done){
-      helper.nock().post("/v1/users/FakeUserId/phoneNumbers", data).reply(201, "", {"Location": "/v1/users/FakeUserId/phoneNumbers/1"});
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(200, item);
-      PhoneNumber.create(data,  function(err, i){
         if(err){
           return done(err);
         }

--- a/test/recording.js
+++ b/test/recording.js
@@ -7,7 +7,6 @@ var Recording = lib.Recording;
 describe("Recording", function(){
   before(function(){
     nock.disableNetConnect();
-    helper.setupGlobalOptions();
   });
   after(function(){
     nock.cleanAll();
@@ -35,31 +34,9 @@ describe("Recording", function(){
         done();
       });
     });
-    it("should return list of recordings (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/recordings?page=1").reply(200, items);
-      Recording.list({page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
     it("should return list of recordings (without query)", function(done){
       helper.nock().get("/v1/users/FakeUserId/recordings").reply(200, items);
       Recording.list(helper.createClient(),  function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of recordings (with default client, without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/recordings").reply(200, items);
-      Recording.list(function(err, list){
         if(err){
           return done(err);
         }
@@ -87,17 +64,6 @@ describe("Recording", function(){
     it("should return a recording", function(done){
       helper.nock().get("/v1/users/FakeUserId/recordings/1").reply(200, item);
       Recording.get(helper.createClient(), "1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should return a recording (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/recordings/1").reply(200, item);
-      Recording.get("1", function(err, i){
         if(err){
           return done(err);
         }


### PR DESCRIPTION
The global configuration and default client features are anti-patterns. A couple reasons come to mind as motivations for removing this feature:
- state
  - right now different client objects share the same state
- security
  - any module in the project can access your catapult credentials with global pattern

I did the following to cleanly remove the global config stuff:
- removed concept of global config
- removed default Client (must now pass it to class methods)
- updated tests

This PR breaks the old API and therefore required a version bump to `2.0.0`.
