### PR TITLE
Gulp, JSHint, and JSCS

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,75 @@
+{
+  "requireCurlyBraces" : [
+    "if", "else", "for", "while", "do", "try", "catch", "case",
+    "default"
+  ],
+
+  "requireSpaceAfterKeywords" : [
+    "if", "else", "for", "while", "do", "switch", "return",
+    "try", "catch"
+  ],
+
+  "requireParenthesesAroundIIFE" : true,
+
+  "requireSpacesInFunctionExpression" : {
+    "beforeOpeningRoundBrace" : true,
+    "beforeOpeningCurlyBrace" : true
+  },
+
+  "disallowMultipleVarDecl"           : true,
+  "disallowEmptyBlocks"               : true,
+  "requireSpacesInsideObjectBrackets" : "all",
+  "requireSpacesInsideArrayBrackets"  : "all",
+  "disallowSpacesInsideParentheses"   : true,
+  "disallowDanglingUnderscores"       : true,
+  "requireSpaceAfterObjectKeys"       : true,
+  "requireCommaBeforeLineBreak"       : true,
+  "requireAlignedObjectValues"        : "skipWithLineBreak",
+
+  "requireOperatorBeforeLineBreak" : [
+    "?", "+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">",
+    ">=", "<", "<="
+  ],
+
+  "disallowSpaceAfterPrefixUnaryOperators" : [
+    "++", "--", "+", "-", "~", "!"
+  ],
+
+  "disallowSpaceBeforePostfixUnaryOperators" : [ "++", "--" ],
+
+  "requireSpaceBeforeBinaryOperators" : [
+    "?", "+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">",
+    ">=", "<", "<="
+  ],
+
+  "disallowSpaceBeforeBinaryOperators" : [ "," ],
+
+  "requireSpaceAfterBinaryOperators" : [
+    "?", "+", "/", "*", ":", "=", "==", "===", "!=", "!==", ">",
+    ">=", "<", "<="
+  ],
+
+  "disallowImplicitTypeConversion" : [
+    "numeric", "boolean", "binary", "string"
+  ],
+
+  "disallowKeywords" : [ "with" ],
+
+  "disallowMultipleLineStrings" : true,
+  "disallowMultipleLineBreaks"  : true,
+  "validateLineBreaks"          : "LF",
+  "validateQuoteMarks"          : "\"",
+  "validateIndentation"         : "\t",
+  "disallowMixedSpacesAndTabs"  : true,
+  "disallowTrailingWhitespace"  : true,
+
+  "requireKeywordsOnNewLine" : [ "else", "catch", "finally" ],
+
+  "maximumLineLength"              : 120,
+  "requireCapitalizedConstructors" : true,
+  "safeContextKeyword"             : "self",
+  "requireDotNotation"             : true,
+
+  "excludeFiles" : [ "node_modules/**" ]
+
+}

--- a/.jscsrc
+++ b/.jscsrc
@@ -23,6 +23,7 @@
   "disallowSpacesInsideParentheses"   : true,
   "disallowDanglingUnderscores"       : true,
   "requireSpaceAfterObjectKeys"       : true,
+  "requireSpaceBeforeBlockStatements" : true,
   "requireCommaBeforeLineBreak"       : true,
   "requireAlignedObjectValues"        : "skipWithLineBreak",
 

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,29 @@
+{
+  "bitwise"       : true,
+  "camelcase"     : true,
+  "curly"         : true,
+  "eqeqeq"        : true,
+  "es3"           : false,
+  "forin"         : false,
+  "immed"         : true,
+  "indent"        : 4,
+  "latedef"       : true,
+  "newcap"        : true,
+  "noarg"         : true,
+  "noempty"       : true,
+  "nonew"         : true,
+  "quotmark"      : "double",
+  "undef"         : true,
+  "unused"        : true,
+  "strict"        : true,
+  "globalstrict"  : true,
+  "trailing"      : true,
+  "maxparams"     : 5,
+  "maxdepth"      : 3,
+  "maxstatements" : false,
+  "maxlen"        : 120,
+
+  "node"          : true,
+
+  "proto"         : true
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,7 +35,7 @@ gulp.task("test", function () {
 							}
 						}))
 						.pipe(istanbul.writeReports())
-						.pipe(istanbul.enforceThresholds({ thresholds : { global : 50 } }));
+						.pipe(istanbul.enforceThresholds({ thresholds : { global : 100 } }));
 				});
 		});
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,7 @@ gulp.task("jscs", function () {
 		.pipe(jscs());
 });
 
-gulp.task("test", function (callback) {
+gulp.task("test", function () {
 	return gulp.src("coverage", { read : false })
 	.pipe(clean())
 		.on("end", function () {
@@ -35,8 +35,7 @@ gulp.task("test", function (callback) {
 							}
 						}))
 						.pipe(istanbul.writeReports())
-						.pipe(istanbul.enforceThresholds({ thresholds : { global : 100 } }))
-						.on("end", callback);
+						.pipe(istanbul.enforceThresholds({ thresholds : { global : 50 } }));
 				});
 		});
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,9 +21,9 @@ gulp.task("jscs", function () {
 
 gulp.task("test", function (callback) {
 	return gulp.src("coverage", { read : false })
-        .pipe(clean())
+	.pipe(clean())
 		.on("end", function () {
-			gulp.src([ "test/*.js" ])
+			gulp.src([ "lib/*.js" ])
 				.pipe(istanbul())
 				.pipe(istanbul.hookRequire())
 				.on("finish", function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,49 @@
+"use strict";
+
+var gulp = require("gulp");
+var clean = require("gulp-clean");
+var mocha = require("gulp-mocha");
+var jshint = require("gulp-jshint");
+var jscs = require("gulp-jscs");
+var istanbul = require("gulp-istanbul");
+
+gulp.task("jshint", function () {
+	return gulp.src([ "./lib/*.js", "./test/*.js" ])
+		.pipe(jshint())
+		.pipe(jshint.reporter("jshint-stylish"))
+		.pipe(jshint.reporter("fail"));
+});
+
+gulp.task("jscs", function () {
+	return gulp.src([ "./lib/*.js", "./test/*.js" ])
+		.pipe(jscs());
+});
+
+gulp.task("test", function (callback) {
+	return gulp.src("coverage", { read : false })
+        .pipe(clean())
+		.on("end", function () {
+			gulp.src([ "test/*.js" ])
+				.pipe(istanbul())
+				.pipe(istanbul.hookRequire())
+				.on("finish", function () {
+					gulp.src([ "test/*.js" ], { read : false })
+						.pipe(mocha({
+							reporter : "spec",
+							globals  : {
+								should : require("should")
+							}
+						}))
+						.pipe(istanbul.writeReports())
+						.pipe(istanbul.enforceThresholds({ thresholds : { global : 100 } }))
+						.on("end", callback);
+				});
+		});
+});
+
+gulp.task("default", [ "jshint", "jscs", "test" ])
+	.on("finish", function () {
+		console.log("All done");
+	}).on("error", function () {
+		console.log("error error error");
+	});

--- a/lib/account.js
+++ b/lib/account.js
@@ -1,45 +1,51 @@
 "use strict";
+
 var Client = require("./client");
 var ACCOUNT_PATH = "account";
 
 module.exports = {
-  /** Get information about your account
-   * @param client optional Client instance
-   * @param callback {Function} callback function
-   * @example
-   *  bandwidth.Account.get(client, function(err, account) { ...});
-   */
-  get: function(client, callback){
-    if(arguments.length === 1){
-      callback = client;
-      client = new Client();
-    }
-    client.makeRequest("get", client.concatUserPath(ACCOUNT_PATH), callback);
-  },
-  /** Get a list of the transactions made to your account
-   * @param client optional Client instance
-   * @param query optional query parameters
-   * @param callback {Function} callback function
-   * @example
-   *  bandwidth.Account.getTransactions(client, function(err, transactions){ ...});
-   */
-  getTransactions: function(client, query, callback){
-    if(arguments.length === 1){
-      callback = client;
-      client = new Client();
-    }
-    if(arguments.length === 2){
-      callback = query;
-      if(client instanceof Client){
-        query = {};
-      }
-      else{
-        query = client;
-        client = new Client();
-      }
-    }
-    client.makeRequest("get", client.concatUserPath(ACCOUNT_PATH) + "/transactions", query,  callback);
-  }
+
+	/**
+	 * Get information about your account
+	 * @param client optional Client instance
+	 * @param callback {Function} callback function
+	 * @example
+	 *  bandwidth.Account.get(client, function(err, account) { ...});
+	 */
+	get : function (client, callback) {
+		if (arguments.length === 1) {
+			callback = client;
+			client = new Client();
+		}
+
+		client.makeRequest("get", client.concatUserPath(ACCOUNT_PATH), callback);
+	},
+
+	/**
+	 * Get a list of the transactions made to your account
+	 * @param client optional Client instance
+	 * @param query optional query parameters
+	 * @param callback {Function} callback function
+	 * @example
+	 *  bandwidth.Account.getTransactions(client, function(err, transactions){ ...});
+	 */
+	getTransactions : function (client, query, callback) {
+		if (arguments.length === 1) {
+			callback = client;
+			client = new Client();
+		}
+
+		if (arguments.length === 2) {
+			callback = query;
+			if (client instanceof Client) {
+				query = {};
+			}
+			else {
+				query = client;
+				client = new Client();
+			}
+		}
+
+		client.makeRequest("get", client.concatUserPath(ACCOUNT_PATH) + "/transactions", query,  callback);
+	}
 };
-
-

--- a/lib/application.js
+++ b/lib/application.js
@@ -1,124 +1,139 @@
 "use strict";
+
 var Client = require("./client");
 var APPLICATION_PATH = "applications";
 
-function Application(){
-  //compabtibility fix
-  if(arguments.length > 0){
-    this.name = arguments[0];
-    this.incomingCallUrl = arguments[1];
-    this.incomingSmsUrl = arguments[2];
-    this.script = arguments[3];
-  }
+function Application() {
+	//compabtibility fix
+	if (arguments.length > 0) {
+		this.name = arguments[0];
+		this.incomingCallUrl = arguments[1];
+		this.incomingSmsUrl = arguments[2];
+		this.script = arguments[3];
+	}
 }
 
-/** Get information about an application
+/**
+ * Get information about an application
  * @param client optional Client instance
  * @param id id of Application*
  * @param callback callback function
  * @example
  * bandwidth.Application.get(client, "id", function(err, app){...});
- * */
-Application.get = function(client, id, callback){
-  if(arguments.length === 2){
-    callback = id;
-    id = client;
-    client = new Client();
-  }
-  client.makeRequest("get", client.concatUserPath(APPLICATION_PATH) + "/" +  id, function(err, item){
-    if(err){
-      return callback(err);
-    }
-    item.client = client;
-    item.__proto__ = Application.prototype;
-    callback(null, item);
-  });
+ */
+
+Application.get = function (client, id, callback) {
+	if (arguments.length === 2) {
+		callback = id;
+		id = client;
+		client = new Client();
+	}
+
+	client.makeRequest("get", client.concatUserPath(APPLICATION_PATH) + "/" +  id, function (err, item) {
+		if (err) {
+			return callback(err);
+		}
+
+		item.client = client;
+		item.__proto__ = Application.prototype;
+		callback(null, item);
+	});
 };
 
-/** Get a list of your applications
+/**
+ * Get a list of your applications
  * @param client Client instance
  * @param query query parameters
  * @param callback callback function
  * @example
  * bandwidth.application.list(client, function(err, apps){...});
- * */
-Application.list = function(client, query, callback){
-  if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-    query = {};
-  }
-  if(arguments.length === 2){
-    callback = query;
-    if(client instanceof Client){
-      query = {};
-    }
-    else{
-      query = client;
-      client = new Client();
-    }
-  }
-  client.makeRequest("get", client.concatUserPath(APPLICATION_PATH), query, function(err, items){
-    if(err){
-      return callback(err);
-    }
-    items = items || [];
-    var result = items.map(function(item){
-      item.client = client;
-      item.__proto__ = Application.prototype;
-      return item;
-    });
-    callback(null, result);
-  });
+ */
+Application.list = function (client, query, callback) {
+
+	if (arguments.length === 1) {
+		callback = client;
+		client = new Client();
+		query = {};
+	}
+
+	if (arguments.length === 2) {
+		callback = query;
+		if (client instanceof Client) {
+			query = {};
+		}
+		else {
+			query = client;
+			client = new Client();
+		}
+	}
+
+	client.makeRequest("get", client.concatUserPath(APPLICATION_PATH), query, function (err, items) {
+		if (err) {
+			return callback(err);
+		}
+
+		items = items || [];
+		var result = items.map(function (item) {
+			item.client = client;
+			item.__proto__ = Application.prototype;
+			return item;
+		});
+
+		callback(null, result);
+	});
 };
 
-/** Create an application
+/**
+ * Create an application
  * @param client Client instance
  * @param item data to create application
  * @param callback callback function
  * @example
  * bandwidth.Application.create(client, {name: "test", incomingCallUrl: "url"}, function(err, app){});
- * */
-Application.create = function(client, item, callback){
-  if(arguments.length === 2){
-    callback = item;
-    item = client;
-    client = new Client();
-  }
-  var request = client.createRequest("post", client.concatUserPath(APPLICATION_PATH));
-  request.type("json").send(item).end(function(res){
-    if(res.ok && res.headers.location){
-      Client.getIdFromLocationHeader(res.headers.location, function(err, id){
-        if(err){
-          return callback(err);
-        }
-        Application.get(client, id, callback);
-      });
-    }
-    else{
-      client.checkResponse(res, callback);
-    }
-  });
+ */
+Application.create = function (client, item, callback) {
+	if (arguments.length === 2) {
+		callback = item;
+		item = client;
+		client = new Client();
+	}
+
+	var request = client.createRequest("post", client.concatUserPath(APPLICATION_PATH));
+	request.type("json").send(item).end(function (res) {
+		if (res.ok && res.headers.location) {
+			Client.getIdFromLocationHeader(res.headers.location, function (err, id) {
+				if (err) {
+					return callback(err);
+				}
+
+				Application.get(client, id, callback);
+			});
+		}
+		else {
+			client.checkResponse(res, callback);
+		}
+	});
 };
 
-/** Make changes to an application
+/**
+ * Make changes to an application
  * @param data changed data
  * @param callback callback function
  * @example
  * app.update({callbackUrl: "http://host1", function(err){...});
- * */
-Application.prototype.update = function(data, callback){
-  this.client.makeRequest("post", this.client.concatUserPath(APPLICATION_PATH) + "/" + this.id,  data, callback);
+ */
+Application.prototype.update = function (data, callback) {
+	this.client.makeRequest("post", this.client.concatUserPath(APPLICATION_PATH) + "/" + this.id,  data, callback);
 
 };
 
-/** Delete an application
+/**
+ * Delete an application
  * @example
  * app.delete(function(err){...});
- * */
-Application.prototype.delete = function(callback){
-  this.client.makeRequest("del", this.client.concatUserPath(APPLICATION_PATH) + "/" + this.id,  callback);
+ */
+Application.prototype.delete = function (callback) {
+	this.client.makeRequest("del", this.client.concatUserPath(APPLICATION_PATH) + "/" + this.id,  callback);
 };
-
 
 module.exports = Application;

--- a/lib/availableNumber.js
+++ b/lib/availableNumber.js
@@ -1,57 +1,64 @@
 "use strict";
+
 var Client = require("./client");
 var AVAILABLE_NUMBERS_PATH = "availableNumbers";
-module.exports = function(){
-  //for compatibility only
+
+module.exports = function () {
+	//for compatibility only
 };
-/** Search for available toll free numbers
+
+/**
+ * Search for available toll free numbers
  * @param client CLient instance
  * @param query query parameters
  * @param callback callback function
  * @example
  * bandwidth.AvailableNumber.searchTollfree(client, {quantity: 20}, function(err, numbers){...});
- * */
-module.exports.searchTollFree = function(client, query, callback){
-  if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-  }
-  if(arguments.length === 2){
-    callback = query;
-    if(client instanceof Client){
-      query = {};
-    }
-    else{
-      query = client;
-      client = new Client();
-    }
-  }
-  client.makeRequest("get", AVAILABLE_NUMBERS_PATH + "/tollFree", query, callback);
+ */
+module.exports.searchTollFree = function (client, query, callback) {
+	if (arguments.length === 1) {
+		callback = client;
+		client = new Client();
+	}
+
+	if (arguments.length === 2) {
+		callback = query;
+		if (client instanceof Client) {
+			query = {};
+		}
+		else {
+			query = client;
+			client = new Client();
+		}
+	}
+
+	client.makeRequest("get", AVAILABLE_NUMBERS_PATH + "/tollFree", query, callback);
 };
 
-/** Search for available local numbers
+/**
+ * Search for available local numbers
  * @param client Client instance
  * @param query query parameters
  * @paarm callback callback function
  * @example
  * bandwidth.AvailableNumber.searchLocal(client, {state: "", zip: "", areaCode: ""},, function(err, numbers){ ... });
- * */
-module.exports.searchLocal = function(client, query, callback){
-  if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-  }
-  if(arguments.length === 2){
-    callback = query;
-    if(client instanceof Client){
-      query = {};
-    }
-    else{
-      query = client;
-      client = new Client();
-    }
-  }
-  client.makeRequest("get", AVAILABLE_NUMBERS_PATH + "/local", query, callback);
+ */
+module.exports.searchLocal = function (client, query, callback) {
+	if (arguments.length === 1) {
+		callback = client;
+		client = new Client();
+	}
+
+	if (arguments.length === 2) {
+		callback = query;
+		if (client instanceof Client) {
+			query = {};
+		}
+		else {
+			query = client;
+			client = new Client();
+		}
+	}
+
+	client.makeRequest("get", AVAILABLE_NUMBERS_PATH + "/local", query, callback);
 };
-
-

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -1,125 +1,143 @@
 "use strict";
+
 var Client = require("./client");
 var Call = require("./call");
 var BRIDGE_PATH = "bridges";
 
-function Bridge(){
+function Bridge() {
 }
-/** Get information about an specific bridge
+
+/**
+ * Get information about an specific bridge
  * @param client Client instance
  * @param id Id of Bridge
  * @param callback callback function
  * @example
  * bandwidth.Bridge.get(client, "id", function(err, bridge){...});
- * */
-Bridge.get = function(client, id, callback){
-  if(arguments.length === 2){
-    callback = id;
-    id = client;
-    client = new Client();
-  }
-  client.makeRequest("get", client.concatUserPath(BRIDGE_PATH) + "/" +  id, function(err, item){
-    if(err){
-      return callback(err);
-    }
-    item.client = client;
-    item.__proto__ = Bridge.prototype;
-    callback(null, item);
-  });
+ */
+Bridge.get = function (client, id, callback) {
+	if (arguments.length === 2) {
+		callback = id;
+		id = client;
+		client = new Client();
+	}
+
+	client.makeRequest("get", client.concatUserPath(BRIDGE_PATH) + "/" +  id, function (err, item) {
+		if (err) {
+			return callback(err);
+		}
+
+		item.client = client;
+		item.__proto__ = Bridge.prototype;
+		callback(null, item);
+	});
 };
 
-/** Get a list of previous bridges
+/**
+ * Get a list of previous bridges
  * @param client Client instance
  * @param callback callback function
  * @example
  * bandwidth.Bridgw.list(client, function(err, list){});
- * */
-Bridge.list = function(client, callback){
-  if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-  }
-  client.makeRequest("get", client.concatUserPath(BRIDGE_PATH), function(err, items){
-    if(err){
-      return callback(err);
-    }
-    items = items || [];
-    var result = items.map(function(item){
-      item.client = client;
-      item.__proto__ = Bridge.prototype;
-      return item;
-    });
-    callback(null, result);
-  });
+ */
+Bridge.list = function (client, callback) {
+	if (arguments.length === 1) {
+		callback = client;
+		client = new Client();
+	}
+
+	client.makeRequest("get", client.concatUserPath(BRIDGE_PATH), function (err, items) {
+		if (err) {
+			return callback(err);
+		}
+
+		items = items || [];
+		var result = items.map(function (item) {
+			item.client = client;
+			item.__proto__ = Bridge.prototype;
+			return item;
+		});
+
+		callback(null, result);
+	});
 };
 
-/** Create a bridge
+/**
+ * Create a bridge
  * @param client Client instance
  * @param item bridge data
  * @param callback callback function
  * @example
  * bandwidth.Bridge.create(client, {callIds: ["id1", "id2"]}, function(err, bridge){});
- * */
-Bridge.create = function(client, item, callback){
-  if(arguments.length === 2){
-    callback = item;
-    item = client;
-    client = new Client();
-  }
-  var request = client.createRequest("post", client.concatUserPath(BRIDGE_PATH));
-  request.type("json").send(item).end(function(res){
-    if(res.ok && res.headers.location){
-      Client.getIdFromLocationHeader(res.headers.location, function(err, id){
-        if(err){
-          return callback(err);
-        }
-        Bridge.get(client, id, callback);
-      });
-    }
-    else{
-      client.checkResponse(res, callback);
-    }
-  });
+ */
+Bridge.create = function (client, item, callback) {
+	if (arguments.length === 2) {
+		callback = item;
+		item = client;
+		client = new Client();
+	}
+
+	var request = client.createRequest("post", client.concatUserPath(BRIDGE_PATH));
+	request.type("json").send(item).end(function (res) {
+		if (res.ok && res.headers.location) {
+			Client.getIdFromLocationHeader(res.headers.location, function (err, id) {
+				if (err) {
+					return callback(err);
+				}
+
+				Bridge.get(client, id, callback);
+			});
+		}
+		else {
+			client.checkResponse(res, callback);
+		}
+	});
 };
 
-/** Add one or two calls in a bridge and also put the bridge on hold/unhold
+/**
+ * Add one or two calls in a bridge and also put the bridge on hold/unhold
  * @param data changed data
  * @param callback callback function
  * @example
  * bridge.update({callIds: ["id1"]}, function(err){});
- * */
-Bridge.prototype.update = function(data, callback){
-  this.client.makeRequest("post", this.client.concatUserPath(BRIDGE_PATH) + "/" + this.id,  data, callback);
+ */
+Bridge.prototype.update = function (data, callback) {
+	this.client.makeRequest("post", this.client.concatUserPath(BRIDGE_PATH) + "/" + this.id,  data, callback);
 };
 
-/** Play an audio or speak a sentence in a bridge
+/**
+ * Play an audio or speak a sentence in a bridge
  * @param data audio data
  * @param callback callback function
  * @example
  * bridge.playAudio({fileUrl: ""}, function(err){});
  */
-Bridge.prototype.playAudio = function(data, callback){
-  this.client.makeRequest("post", this.client.concatUserPath(BRIDGE_PATH) + "/" + this.id + "/audio",  data, callback);
+Bridge.prototype.playAudio = function (data, callback) {
+	this.client.makeRequest("post", this.client.concatUserPath(BRIDGE_PATH) + "/" +
+		this.id + "/audio",  data, callback);
 };
 
-/** Get the calls that are on the bridge
+/**
+ * Get the calls that are on the bridge
  * @example
  * bridge.getCalls(function(err, calls){})
- * */
-Bridge.prototype.getCalls = function(callback){
-  var client = this.client;
-  client.makeRequest("get", client.concatUserPath(BRIDGE_PATH) + "/" + this.id + "/calls", function(err, items){
-    if(err){
-      return callback(err);
-    }
-    items = items || [];
-    var result = items.map(function(item){
-      item.client = client;
-      item.__proto__ = Call.prototype;
-      return item;
-    });
-    callback(null, result);
-  });
+ */
+Bridge.prototype.getCalls = function (callback) {
+	var client = this.client;
+	client.makeRequest("get", client.concatUserPath(BRIDGE_PATH) + "/" + this.id + "/calls", function (err, items) {
+		if (err) {
+			return callback(err);
+		}
+
+		items = items || [];
+		var result = items.map(function (item) {
+			item.client = client;
+			item.__proto__ = Call.prototype;
+			return item;
+		});
+
+		callback(null, result);
+	});
 };
 
 module.exports = Bridge;

--- a/lib/call.js
+++ b/lib/call.js
@@ -1,143 +1,159 @@
 "use strict";
+
 var Client = require("./client");
 var CALL_PATH = "calls";
 
-function Call(){
-  //for compatibility
-  if(arguments.length > 0){
-    this.from = arguments[0];
-    this.to = arguments[1];
-  }
+function Call() {
+	//for compatibility
+	if (arguments.length > 0) {
+		this.from = arguments[0];
+		this.to = arguments[1];
+	}
 }
 
-/** Get information about a call that was made or received
+/**
+ * Get information about a call that was made or received
  * @param client Client instance
  * @param id Id of call
  * @param callback callback function
  * @example
  * bandwidth.Client.get(client, "id", function(err, call){});
- * */
-Call.get = function(client, id, callback){
-  if(arguments.length === 2){
-    callback = id;
-    id = client;
-    client = new Client();
-  }
-  client.makeRequest("get", client.concatUserPath(CALL_PATH) + "/" +  id, function(err, item){
-    if(err){
-      return callback(err);
-    }
-    item.client = client;
-    item.__proto__ = Call.prototype;
-    callback(null, item);
-  });
+ */
+Call.get = function (client, id, callback) {
+	if (arguments.length === 2) {
+		callback = id;
+		id = client;
+		client = new Client();
+	}
+
+	client.makeRequest("get", client.concatUserPath(CALL_PATH) + "/" +  id, function (err, item) {
+		if (err) {
+			return callback(err);
+		}
+
+		item.client = client;
+		item.__proto__ = Call.prototype;
+		callback(null, item);
+	});
 };
 
-/** Get a list of previous calls that were made or received
- *  @param client Client instance
- *  @param query query parametes
- *  @param callback callback function
- *  @example
- *  bandwidth.Call.list(client, function(err, list){});
- * */
-Call.list = function(client, query, callback){
-  if(arguments.length === 2){
-    callback = query;
-    if(client instanceof Client){
-      query = {};
-    }
-    else{
-      query = client;
-      client = new Client();
-    }
-  }
-  else if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-    query = {};
-  }
-  client.makeRequest("get", client.concatUserPath(CALL_PATH), query, function(err, items){
-    if(err){
-      return callback(err);
-    }
-    items = items || [];
-    var result = items.map(function(item){
-      item.client = client;
-      item.__proto__ = Call.prototype;
-      return item;
-    });
-    callback(null, result);
-  });
-};
-
-/** Make a phone call
+/**
+ * Get a list of previous calls that were made or received
  * @param client Client instance
- * @param item call's data
+ * @param query query parametes
  * @param callback callback function
- * #example
- * bandwidth.Call.create(client, {from: "", to: ""}, function(err, call){});
- * */
-Call.create = function(client, item, callback){
-  if(arguments.length === 2){
-    callback = item;
-    item = client;
-    client = new Client();
-  }
-  var request = client.createRequest("post", client.concatUserPath(CALL_PATH));
-  request.type("json").send(item).end(function(res){
-    if(res.ok && res.headers.location){
-      Client.getIdFromLocationHeader(res.headers.location, function(err, id){
-        if(err){
-          return callback(err);
-        }
-        Call.get(client, id, callback);
-      });
-    }
-    else{
-      client.checkResponse(res, callback);
-    }
-  });
+ * @example
+ * bandwidth.Call.list(client, function(err, list){});
+ */
+Call.list = function (client, query, callback) {
+	if (arguments.length === 2) {
+		callback = query;
+		if (client instanceof Client) {
+			query = {};
+		}
+		else {
+			query = client;
+			client = new Client();
+		}
+	}
+	else if (arguments.length === 1) {
+		callback = client;
+		client = new Client();
+		query = {};
+	}
+
+	client.makeRequest("get", client.concatUserPath(CALL_PATH), query, function (err, items) {
+		if (err) {
+			return callback(err);
+		}
+
+		items = items || [];
+		var result = items.map(function (item) {
+			item.client = client;
+			item.__proto__ = Call.prototype;
+			return item;
+		});
+
+		callback(null, result);
+	});
 };
 
-/** Make changes to an active phone call. E.g.: transfer, hang up, answer or reject incoming calls, call recording, etc.
+/**
+ * Make a phone call
+ * @param client Client instance
+ * @param item call"s data
+ * @param callback callback function
+ * @example
+ * bandwidth.Call.create(client, {from: "", to: ""}, function(err, call){});
+ */
+Call.create = function (client, item, callback) {
+	if (arguments.length === 2) {
+		callback = item;
+		item = client;
+		client = new Client();
+	}
+
+	var request = client.createRequest("post", client.concatUserPath(CALL_PATH));
+	request.type("json").send(item).end(function (res) {
+		if (res.ok && res.headers.location) {
+			Client.getIdFromLocationHeader(res.headers.location, function (err, id) {
+				if (err) {
+					return callback(err);
+				}
+
+				Call.get(client, id, callback);
+			});
+		}
+		else {
+			client.checkResponse(res, callback);
+		}
+	});
+};
+
+/**
+ * Make changes to an active phone call. E.g.: transfer, hang up, answer or reject incoming calls, call recording, etc.
  * @param client Client instance
  * @param id Id of call
  * @param data changed data
  * @param callback callback function
  * @example
  * bandwidth.Call.update(client, "id", {state: "rejected"}, function(err){}) ;
- * */
-Call.update = function(client, id, data, callback){
-  if(arguments.length === 3){
-    callback = data;
-    data = id;
-    id = client;
-    client = new Client();
-  }
-  client.makeRequest("post", client.concatUserPath(CALL_PATH) + "/" + id, data, callback);
+ */
+Call.update = function (client, id, data, callback) {
+	if (arguments.length === 3) {
+		callback = data;
+		data = id;
+		id = client;
+		client = new Client();
+	}
+
+	client.makeRequest("post", client.concatUserPath(CALL_PATH) + "/" + id, data, callback);
 };
 
-/** Make changes to an active phone call. E.g.: transfer, hang up, answer or reject incoming calls, call recording, etc.
+/**
+ * Make changes to an active phone call. E.g.: transfer, hang up, answer or reject incoming calls, call recording, etc.
  * @param data changed data
  * @param callback callback function
  * @example
  * call.update({state: "rejected"}, function(err){}) ;
- * */
-Call.prototype.update = function(data, callback){
-  this.client.makeRequest("post", this.client.concatUserPath(CALL_PATH) + "/" + this.id,  data, callback);
+ */
+Call.prototype.update = function (data, callback) {
+	this.client.makeRequest("post", this.client.concatUserPath(CALL_PATH) + "/" + this.id,  data, callback);
 };
 
-/** Play an audio or speak a sentence in a call
+/**
+ * Play an audio or speak a sentence in a call
  * @param data audio data
  * @param callback callback function
  * @example
  * call.playAudio({fileUrl: ""}, function(err}{});
- * */
-Call.prototype.playAudio = function(data, callback){
-  this.client.makeRequest("post", this.client.concatUserPath(CALL_PATH) + "/" + this.id + "/audio",  data, callback);
+ */
+Call.prototype.playAudio = function (data, callback) {
+	this.client.makeRequest("post", this.client.concatUserPath(CALL_PATH) + "/" + this.id + "/audio",  data, callback);
 };
 
-/** Speak a sentence in a call
+/**
+ * Speak a sentence in a call
  * @param sentence sentence to speak
  * @param tag optional tag value which will be used in events
  * @param gender optional gender value (default: female)
@@ -146,215 +162,240 @@ Call.prototype.playAudio = function(data, callback){
  * @example
  * call.speakSentence("test", "tag", function(err){});
  */
-Call.prototype.speakSentence = function(sentence, tag, gender, voice, callback){
-  if(arguments.length === 2){
-    callback = tag;
-    tag = null;
-  }
-  else if(arguments.length === 3){
-    callback = gender;
-    gender = null;
-  }
-  else if(arguments.length === 4){
-    callback = voice;
-    return callback(new Error("Parameters 'gender' and 'voice' should be used together"));
-  }
-  this.playAudio({
-    gender: gender || "female",
-    locale: "en_US",
-    voice: voice || "kate",
-    sentence: sentence,
-    tag: tag
-  }, callback);
+Call.prototype.speakSentence = function (sentence, tag, gender, voice, callback) {
+	if (arguments.length === 2) {
+		callback = tag;
+		tag = null;
+	}
+	else if (arguments.length === 3) {
+		callback = gender;
+		gender = null;
+	}
+	else if (arguments.length === 4) {
+		callback = voice;
+		return callback(new Error("Parameters \"gender\" and \"voice\" should be used together"));
+	}
+
+	this.playAudio({
+		gender   : gender || "female",
+		locale   : "en_US",
+		voice    : voice || "kate",
+		sentence : sentence,
+		tag      : tag
+	}, callback);
 };
 
-/** Play audio file in call
+/**
+ * Play audio file in call
  * @param recordingUrl url to audio file
  * @param callback callback function
  * @example
  * call.playRecording("url", function(err){});
  */
-Call.prototype.playRecording = function(recordingUrl, callback){
-  this.playAudio({
-    fileUrl: recordingUrl,
-  }, callback);
+Call.prototype.playRecording = function (recordingUrl, callback) {
+	this.playAudio({
+		fileUrl : recordingUrl
+	}, callback);
 };
 
-/** Send DTMF
+/**
+ * Send DTMF
  * @param dtmf stmv value
  * @param callback callback function
  * @example
  * call.setDtmf("0", function(err){});*/
-Call.prototype.setDtmf = function(dtmf, callback){
-  this.client.makeRequest("post", this.client.concatUserPath(CALL_PATH) + "/" + this.id + "/dtmf",  {dtmfOut: dtmf}, callback);
+Call.prototype.setDtmf = function (dtmf, callback) {
+	this.client.makeRequest("post", this.client.concatUserPath(CALL_PATH) + "/" +
+		this.id + "/dtmf",  { dtmfOut : dtmf }, callback);
 };
 
-/** Gather the DTMF digits pressed
- * @param data gather's data
+/**
+ * Gather the DTMF digits pressed
+ * @param data gather"s data
  * @param callback callback function
  * @example
  * call.createGather("Press a digit", function(err, gather){})
  * call.createGather({maxDigits: 1, prompt: {sentence: "Press a digit", bargeable: true }}, function(err, gather){})
- * */
-Call.prototype.createGather = function(data, callback){
-  if(typeof data === "string"){
-    data = {
-      tag: this.id,
-      maxDigits: 1,
-      prompt: {
-        locale: "en_US",
-        gender: "female",
-        sentence: data,
-        voice: "kate",
-        bargeable: true
-      }
-    };
-  }
-  var self = this;
-  var request = self.client.createRequest("post", self.client.concatUserPath(CALL_PATH) + "/" + this.id + "/gather");
-  request.type("json").send(data).end(function(res){
-    if(res.ok && res.headers.location){
-      Client.getIdFromLocationHeader(res.headers.location, function(err, id){
-        if(err){
-          return callback(err);
-        }
-        self.getGather(id, callback);
-      });
-    }
-    else{
-      self.client.checkResponse(res, callback);
-    }
-  });
+ */
+Call.prototype.createGather = function (data, callback) {
+	if (typeof data === "string") {
+		data = {
+			tag       : this.id,
+			maxDigits : 1,
+			prompt    : {
+				locale    : "en_US",
+				gender    : "female",
+				sentence  : data,
+				voice     : "kate",
+				bargeable : true
+			}
+		};
+	}
+
+	var self = this;
+	var request = self.client.createRequest("post", self.client.concatUserPath(CALL_PATH) + "/" + this.id + "/gather");
+	request.type("json").send(data).end(function (res) {
+		if (res.ok && res.headers.location) {
+			Client.getIdFromLocationHeader(res.headers.location, function (err, id) {
+				if (err) {
+					return callback(err);
+				}
+
+				self.getGather(id, callback);
+			});
+		}
+		else {
+			self.client.checkResponse(res, callback);
+		}
+	});
 };
 
-/** Update the gather DTMF (Stop Gather)
+/**
+ * Update the gather DTMF (Stop Gather)
  * @param gatherId Id of gather
  * @param data changed data
  * @param callback callback function
- * @example
- * call.updateGather("id", {state: "completed"}, function(err){});*/
-Call.prototype.updateGather = function(gatherId, data, callback){
-  this.client.makeRequest("post", this.client.concatUserPath(CALL_PATH + "/" + this.id + "/gather/" + gatherId), data, callback);
+ * @example call.updateGather("id", { state: "completed" }, function(err) { });
+ */
+Call.prototype.updateGather = function (gatherId, data, callback) {
+	this.client.makeRequest("post", this.client.concatUserPath(CALL_PATH + "/" +
+		this.id + "/gather/" + gatherId), data, callback);
 };
 
-/** Get the gather DTMF parameters and results
+/**
+ * Get the gather DTMF parameters and results
  * @param gatherId Id of gather
  * @param callback callback function
- * @example
- * call.getGather("1", function(err, gather){});*/
-Call.prototype.getGather = function(gatherId, callback){
-  this.client.makeRequest("get", this.client.concatUserPath(CALL_PATH + "/" + this.id + "/gather/" + gatherId), callback);
+ * @example call.getGather("1", function(err, gather){ });
+ */
+Call.prototype.getGather = function (gatherId, callback) {
+	this.client.makeRequest("get", this.client.concatUserPath(CALL_PATH + "/" +
+		this.id + "/gather/" + gatherId), callback);
 };
 
-/** Gets information about one call event
+/**
+ * Gets information about one call event
  * @param eventId Id of event
  * @param callback callback function
- * @example
- * call.getEvent("id", function(err, ev){});*/
-Call.prototype.getEvent = function(eventId, callback){
-  this.client.makeRequest("get", this.client.concatUserPath(CALL_PATH + "/" + this.id + "/events/" + eventId), callback);
+ * @example call.getEvent("id", function(err, ev){ });
+ */
+Call.prototype.getEvent = function (eventId, callback) {
+	this.client.makeRequest("get", this.client.concatUserPath(CALL_PATH + "/" +
+		this.id + "/events/" + eventId), callback);
 };
 
-/** Gets the list of call events for a call
- * @example
- * call.getEvents(function(err, list){});*/
-Call.prototype.getEvents = function(callback){
-  this.client.makeRequest("get", this.client.concatUserPath(CALL_PATH + "/" + this.id + "/events"), callback);
+/**
+ * Gets the list of call events for a call
+ * @example call.getEvents(function(err, list) { });
+ */
+Call.prototype.getEvents = function (callback) {
+	this.client.makeRequest("get", this.client.concatUserPath(CALL_PATH + "/" + this.id + "/events"), callback);
 };
 
-/** Retrieve all recordings related to the call
+/**
+ * Retrieve all recordings related to the call
  * @param callback callback function
- * @example
- * call.getRecordings(function(err, list){})*/
-Call.prototype.getRecordings = function(callback){
-  this.client.makeRequest("get", this.client.concatUserPath(CALL_PATH + "/" + this.id + "/recordings"), callback);
+ * @example call.getRecordings(function(err, list){ })
+ */
+Call.prototype.getRecordings = function (callback) {
+	this.client.makeRequest("get", this.client.concatUserPath(CALL_PATH + "/" + this.id + "/recordings"), callback);
 };
 
-/** Hangup a call
+/**
+ * Hangup a call
  * @param callback callback function
- * @example
- * call.hangUp(function(err){});
- * */
-Call.prototype.hangUp = function(callback){
-  var self = this;
-  self.update({state: "completed"}, function(err){
-    if(err){
-      return callback(err);
-    }
-    self.reload(callback);
-  });
+ * @example call.hangUp(function(err) { });
+ */
+Call.prototype.hangUp = function (callback) {
+	var self = this;
+	self.update({ state : "completed" }, function (err) {
+		if (err) {
+			return callback(err);
+		}
+
+		self.reload(callback);
+	});
 };
 
-/** Answer on incoming call
+/**
+ * Answer on incoming call
  * @param callback callback function
- * @example
- * call.answerOnIncoming(function(err){}); */
-Call.prototype.answerOnIncoming = function(callback){
-  var self = this;
-  self.update({state: "active"}, function(err){
-    if(err){
-      return callback(err);
-    }
-    self.reload(callback);
-  });
+ * @example call.answerOnIncoming(function(err) { });
+ */
+Call.prototype.answerOnIncoming = function (callback) {
+	var self = this;
+	self.update({ state : "active" }, function (err) {
+		if (err) {
+			return callback(err);
+		}
+
+		self.reload(callback);
+	});
 };
 
-/** Reject incoming call
+/**
+ * Reject incoming call
  * @param callback callback
- * @example
- * call.rejectIncoming(function(err){});
+ * @example call.rejectIncoming(function(err) { });
  */
-Call.prototype.rejectIncoming = function(callback){
-  var self = this;
-  self.update({state: "rejected"}, function(err){
-    if(err){
-      return callback(err);
-    }
-    self.reload(callback);
-  });
+Call.prototype.rejectIncoming = function (callback) {
+	var self = this;
+	self.update({ state : "rejected" }, function (err) {
+		if (err) {
+			return callback(err);
+		}
+
+		self.reload(callback);
+	});
 };
 
-/** Tune on recording
- * @example
- * call.recordingOn(function(err){});
+/**
+ * Tune on recording
+ * @example call.recordingOn(function(err) { });
  */
-Call.prototype.recordingOn = function(callback){
-  var self = this;
-  self.update({recordingEnabled: true}, function(err){
-    if(err){
-      return callback(err);
-    }
-    self.reload(callback);
-  });
+Call.prototype.recordingOn = function (callback) {
+	var self = this;
+	self.update({ recordingEnabled : true }, function (err) {
+		if (err) {
+			return callback(err);
+		}
+
+		self.reload(callback);
+	});
 };
 
-/** Tune off recording
- * @example
- * call.recordingOff(function(err){});
+/**
+ * Tune off recording
+ * @example call.recordingOff(function(err){ });
  */
-Call.prototype.recordingOff = function(callback){
-  var self = this;
-  self.update({recordingEnabled: false}, function(err){
-    if(err){
-      return callback(err);
-    }
-    self.reload(callback);
-  });
+Call.prototype.recordingOff = function (callback) {
+	var self = this;
+	self.update({ recordingEnabled : false }, function (err) {
+		if (err) {
+			return callback(err);
+		}
+
+		self.reload(callback);
+	});
 };
 
-/** Refresh information about a call */
-Call.prototype.reload = function(callback){
-  var self = this;
-  self.client.makeRequest("get", self.client.concatUserPath(CALL_PATH) + "/" +  self.id, function(err, item){
-    if(err){
-      return callback(err);
-    }
-    var k;
-    for(k in item){
-      self[k] = item[k];
-    }
-    callback();
-  });
+/**
+ * Refresh information about a call
+ */
+Call.prototype.reload = function (callback) {
+	var self = this;
+	self.client.makeRequest("get", self.client.concatUserPath(CALL_PATH) + "/" +  self.id, function (err, item) {
+		if (err) {
+			return callback(err);
+		}
+
+		var k;
+		for (k in item) {
+			self[k] = item[k];
+		}
+
+		callback();
+	});
 };
 
 module.exports = Call;

--- a/lib/client.js
+++ b/lib/client.js
@@ -4,133 +4,136 @@ var errors = require("./errors");
 
 /** Constructor */
 function Client(userId, apiToken, apiSecret, options){
-  if(!(this instanceof Client)){
-    return new Client(userId, apiToken, apiSecret, options);
-  }
-  if(typeof options !== "object" && arguments.length === 4){
-    //compability with previous version of lib
-    var opts = {apiEndPoint: (userId)?("https://" + userId):null};
-    this.host = userId;
-    userId = apiToken;
-    this.userId = userId;
-    apiToken = apiSecret;
-    this.apiToken = apiToken;
-    apiSecret = options;
-    this.secret = apiSecret;
-    options = opts;
-  }
-  if(arguments.length === 1){
-    options = arguments[0];
-    userId = options.userId;
-  }
-  options = options || {};
-  if(!userId){
-    userId = Client.globalOptions.userId;
-  }
-  if(!apiToken){
-    apiToken = options.apiToken || Client.globalOptions.apiToken;
-  }
-  if(!apiSecret){
-    apiSecret = options.apiSecret || Client.globalOptions.apiSecret;
-  }
-  if(!options.apiEndPoint){
-    options.apiEndPoint = Client.globalOptions.apiEndPoint;
-  }
-  if(!options.apiVersion){
-    options.apiVersion = Client.globalOptions.apiVersion;
-  }
-  if(!userId || !apiToken || !apiSecret){
-    throw new errors.MissingCredentialsError();
-  }
-  this.prepareRequest = function(req){
-    return req.auth(apiToken, apiSecret).accept("json");
-  };
+	if (!(this instanceof Client)){
+		return new Client(userId, apiToken, apiSecret, options);
+	}
+	if (typeof options !== "object" && arguments.length === 4){
+		//compability with previous version of lib
+		var opts = { apiEndPoint : (userId)?("https://" + userId):null };
+		this.host = userId;
+		userId = apiToken;
+		this.userId = userId;
+		apiToken = apiSecret;
+		this.apiToken = apiToken;
+		apiSecret = options;
+		this.secret = apiSecret;
+		options = opts;
+	}
+	if (arguments.length === 1){
+		options = arguments[0];
+		userId = options.userId;
+	}
+	options = options || {};
+	if (!userId){
+		userId = Client.globalOptions.userId;
+	}
+	if (!apiToken){
+		apiToken = options.apiToken || Client.globalOptions.apiToken;
+	}
+	if (!apiSecret){
+		apiSecret = options.apiSecret || Client.globalOptions.apiSecret;
+	}
+	if (!options.apiEndPoint){
+		options.apiEndPoint = Client.globalOptions.apiEndPoint;
+	}
+	if (!options.apiVersion){
+		options.apiVersion = Client.globalOptions.apiVersion;
+	}
+	if (!userId || !apiToken || !apiSecret){
+		throw new errors.MissingCredentialsError();
+	}
+	this.prepareRequest = function (req) {
+		return req.auth(apiToken, apiSecret).accept("json");
+	};
 
-  this.concatUserPath = function(path){
-    return "/users/" + userId + ((path[0] == "/")?path:("/" + path));
-  }
+	this.concatUserPath = function (path) {
+		return "/users/" + userId + ((path[0] === "/") ? path : ("/" + path));
+	};
 
-  this.prepareUrl = function(path){
-    return options.apiEndPoint + "/" + options.apiVersion + ((path[0] == "/")?path:("/" + path));
-  };
+	this.prepareUrl = function (path) {
+		return options.apiEndPoint + "/" + options.apiVersion + ((path[0] === "/") ? path : ("/" + path));
+	};
 }
 
 /** global options (used when constructor called without params) */
 Client.globalOptions = {
-  apiEndPoint: "https://api.catapult.inetwork.com",
-  apiVersion: "v1",
-  apiToken: "",
-  apiSecret: "",
-  userId: ""
+	apiEndPoint : "https://api.catapult.inetwork.com",
+	apiVersion  : "v1",
+	apiToken    : "",
+	apiSecret   : "",
+	userId      : ""
 };
 
 /** Extract id from location header */
-Client.getIdFromLocationHeader = function(location, callback){
-  var index = location.lastIndexOf("/");
-  if(index < 0){
-    return callback(new Error("Missing id in response"));
-  }
-  var id = location.substr(index + 1);
-  callback(null, id);
+Client.getIdFromLocationHeader = function (location, callback) {
+	var index = location.lastIndexOf("/");
+	if (index < 0){
+		return callback(new Error("Missing id in response"));
+	}
+	var id = location.substr(index + 1);
+	callback(null, id);
 };
 
 /** Create new request with auth data */
-Client.prototype.createRequest = function(method, path){
-  return this.prepareRequest(superagent[method](this.prepareUrl(path)));
+Client.prototype.createRequest = function (method, path) {
+	return this.prepareRequest(superagent[method](this.prepareUrl(path)));
 };
 
 /** Perform http request to Bandwidth API server */
-Client.prototype.makeRequest = function(method, path){
-  var callback = arguments[arguments.length - 1];
-  var request = this.createRequest(method, path);
-  if(arguments.length > 3){
-    var data = arguments[2];
-   if(method === "get"){
-      request.query(data);
-   }
-   else{
-      request.type("json").send(data);
-   }
-  }
-  var self = this;
-  request.buffer().end(function(res){
-    self.checkResponse(res, callback);
-  });
+Client.prototype.makeRequest = function (method, path) {
+	var callback = arguments[arguments.length - 1];
+	var request = this.createRequest(method, path);
+	if (arguments.length > 3){
+		var data = arguments[2];
+		if (method === "get"){
+			request.query(data);
+		}
+		else {
+			request.type("json").send(data);
+		}
+	}
+	var self = this;
+	request.buffer().end(function (res) {
+		self.checkResponse(res, callback);
+	});
 };
+
+function processResponse (obj) {
+	if (Array.isArray(obj)){
+		var i;
+		var l = obj.length;
+		var list = new Array(l);
+		for (i = 0; i < l; i++) {
+			list[i] = processResponse(obj[i]);
+		}
+		return list;
+	}
+	else if (typeof obj === "object"){
+		var k;
+		var res = {};
+		for (k in obj){
+			res[k] = processResponse(obj[k]);
+		}
+		return res;
+	}
+	else if (typeof obj === "string" && /^\d{4}\-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}(\.\d{3})?Z$/.test(obj)){
+		return new Date(obj);
+	}
+	return obj;
+}
 
 /** Validate response object of http request */
-Client.prototype.checkResponse = function(res, callback){
-  if(res.ok){
-    return callback(null, processResponse(res.body));
-  }
-  if(res.body){
-    var message = res.body.message || res.body.code;
-    if(message){
-      return callback(new errors.BandwidthError(message));
-    }
-  }
-  return callback(new errors.BandwidthError("Http code " + res.status, res.status));
+Client.prototype.checkResponse = function (res, callback) {
+	if (res.ok){
+		return callback(null, processResponse(res.body));
+	}
+	if (res.body){
+		var message = res.body.message || res.body.code;
+		if (message){
+			return callback(new errors.BandwidthError(message));
+		}
+	}
+	return callback(new errors.BandwidthError("Http code " + res.status, res.status));
 };
-
-function processResponse(obj){
-  if(Array.isArray(obj)){
-    var i, l = obj.length, list = new Array(l);
-    for(i = 0; i < l; i ++){
-      list[i] = processResponse(obj[i]);
-    }
-    return list;
-  }
-  else if(typeof obj === "object"){
-    var k, res = {};
-    for(k in obj){
-      res[k] = processResponse(obj[k]);
-    }
-    return res;
-  }
-  else if(typeof obj === "string" && /^\d{4}\-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}(\.\d{3})?Z$/.test(obj)){
-    return new Date(obj);
-  }
-  return obj;
-}
 
 module.exports = Client;

--- a/lib/client.js
+++ b/lib/client.js
@@ -3,11 +3,11 @@ var superagent = require("superagent");
 var errors = require("./errors");
 
 /** Constructor */
-function Client(userId, apiToken, apiSecret, options){
-	if (!(this instanceof Client)){
+function Client(userId, apiToken, apiSecret, options) {
+	if (!(this instanceof Client)) {
 		return new Client(userId, apiToken, apiSecret, options);
 	}
-	if (typeof options !== "object" && arguments.length === 4){
+	if (typeof options !== "object" && arguments.length === 4) {
 		//compability with previous version of lib
 		var opts = { apiEndPoint : (userId)?("https://" + userId):null };
 		this.host = userId;
@@ -19,27 +19,27 @@ function Client(userId, apiToken, apiSecret, options){
 		this.secret = apiSecret;
 		options = opts;
 	}
-	if (arguments.length === 1){
+	if (arguments.length === 1) {
 		options = arguments[0];
 		userId = options.userId;
 	}
 	options = options || {};
-	if (!userId){
+	if (!userId) {
 		userId = Client.globalOptions.userId;
 	}
-	if (!apiToken){
+	if (!apiToken) {
 		apiToken = options.apiToken || Client.globalOptions.apiToken;
 	}
-	if (!apiSecret){
+	if (!apiSecret) {
 		apiSecret = options.apiSecret || Client.globalOptions.apiSecret;
 	}
-	if (!options.apiEndPoint){
+	if (!options.apiEndPoint) {
 		options.apiEndPoint = Client.globalOptions.apiEndPoint;
 	}
-	if (!options.apiVersion){
+	if (!options.apiVersion) {
 		options.apiVersion = Client.globalOptions.apiVersion;
 	}
-	if (!userId || !apiToken || !apiSecret){
+	if (!userId || !apiToken || !apiSecret) {
 		throw new errors.MissingCredentialsError();
 	}
 	this.prepareRequest = function (req) {
@@ -67,7 +67,7 @@ Client.globalOptions = {
 /** Extract id from location header */
 Client.getIdFromLocationHeader = function (location, callback) {
 	var index = location.lastIndexOf("/");
-	if (index < 0){
+	if (index < 0) {
 		return callback(new Error("Missing id in response"));
 	}
 	var id = location.substr(index + 1);
@@ -83,9 +83,9 @@ Client.prototype.createRequest = function (method, path) {
 Client.prototype.makeRequest = function (method, path) {
 	var callback = arguments[arguments.length - 1];
 	var request = this.createRequest(method, path);
-	if (arguments.length > 3){
+	if (arguments.length > 3) {
 		var data = arguments[2];
-		if (method === "get"){
+		if (method === "get") {
 			request.query(data);
 		}
 		else {
@@ -99,7 +99,7 @@ Client.prototype.makeRequest = function (method, path) {
 };
 
 function processResponse (obj) {
-	if (Array.isArray(obj)){
+	if (Array.isArray(obj)) {
 		var i;
 		var l = obj.length;
 		var list = new Array(l);
@@ -108,15 +108,15 @@ function processResponse (obj) {
 		}
 		return list;
 	}
-	else if (typeof obj === "object"){
+	else if (typeof obj === "object") {
 		var k;
 		var res = {};
-		for (k in obj){
+		for (k in obj) {
 			res[k] = processResponse(obj[k]);
 		}
 		return res;
 	}
-	else if (typeof obj === "string" && /^\d{4}\-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}(\.\d{3})?Z$/.test(obj)){
+	else if (typeof obj === "string" && /^\d{4}\-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}(\.\d{3})?Z$/.test(obj)) {
 		return new Date(obj);
 	}
 	return obj;
@@ -124,12 +124,12 @@ function processResponse (obj) {
 
 /** Validate response object of http request */
 Client.prototype.checkResponse = function (res, callback) {
-	if (res.ok){
+	if (res.ok) {
 		return callback(null, processResponse(res.body));
 	}
-	if (res.body){
+	if (res.body) {
 		var message = res.body.message || res.body.code;
-		if (message){
+		if (message) {
 			return callback(new errors.BandwidthError(message));
 		}
 	}

--- a/lib/compatibility.js
+++ b/lib/compatibility.js
@@ -1,212 +1,194 @@
 "use strict";
+
 //Obsolete functions support
-function obsolete(func, detail){
-  var nodeEnv = process.env.NODE_ENV || "development";
-  if(nodeEnv === "development"){
-    console.warn("Obsolete " + func + "(): Use "  + detail + " instead of it.");
-  }
-}
-module.exports = function(lib){
-  var details = {
-    sendCall: "Call.create()",
-    changeCall: "call.update()",
-    startRecording: "call.recordingOn()",
-    stopRecording: "call.recordingOff()",
-    getRecording: "Recording.get()",
-    getRecordings: "call.getRecordings()",
-    transferCall: "call.update()",
-    hangUp: "call.hangUp()",
-    getCall: "Call.get()",
-    playCallAudio: "call.playAudio()",
-    sendMessage: "Message.create()",
-    getMessage: "Message.get()",
-    getMessages: "Message.list()",
-    getAvailableNumbers: "AvailableNumber.searchTollFree() or AvailableNumber.searchToLocal()",
-    acquirePhoneNumber: "PhoneNumber.create()",
-    getPhoneNumber: "PhoneNumber.get()",
-    getPhoneNumbers: "PhoneNumber.list()",
-    deletePhoneNumber: "phoneNumber.delete()",
-    updatePhoneNumber: "phoneNumber.update()",
-    getApplications: "Application.list()",
-    portIn: "Iris API",
-    uploadLOA: "Iris API",
-    cancelPortIn: "Iris API",
-    getPortInState: "Iris API",
-    checkPortInAvailability: "Iris API"
-  };
-  var obsoleteFunctions = {
-    sendCall: function (call, callback){
-      lib.Call.create(this, call, callback);
-    },
-    changeCall: function (callId, data, callback){
-      var call = new lib.Call();
-      call.id = callId;
-      call.client = this;
-      call.update(data, callback);
-    },
-    hangUp: function (callId, callback){
-      this.changeCall(callId, {state: 'completed'}, callback)
-    },
-
-    startRecording: function (callId, callback){
-      this.changeCall(callId, {recordingEnabled: true}, callback)
-    },
-    stopRecording:  function (callId, callback){
-      this.changeCall(callId, {recordingEnabled: false}, callback)
-    },
-    getRecording: function(recordingId, callback){
-      lib.Recording.get(this, recordingId, callback);
-    },
-    getRecordings: function(callId, callback){
-      var call = new lib.Call();
-      call.id = callId;
-      call.client = this;
-      call.getRecordings(callback);
-    },
-    transferCall: function(callTransfer, callback){
-      var callId = callTransfer.call.id;
-      delete callTransfer.call;
-      var call = new lib.Call();
-      call.id = callId;
-      call.client = this;
-      call.update(callTransfer, callback);
-    },
-    getCall: function(callId, callback){
-      lib.Call.get(this, callId, callback);
-    },
-
-    playCallAudio: function(callAudio, callback)
-    {
-      var callId = callAudio.callId;
-      delete callAudio.callId;
-      var call = new lib.Call();
-      call.id = callId;
-      call.client = this;
-      call.playAudio(callAudio, callback);
-    },
-    sendMessage: function(message, callback){
-      lib.Message.create(this, message, callback);
-    },
-    getMessage: function(messageId, callback){
-      lib.Message.get(this, messageId, callback);
-    },
-    getMessages: function(callback){
-      lib.Message.list(this, callback);
-    },
-    getAvailableNumbers: function(parameters, callback){
-      var search = lib.AvailableNumber[(parameters.numberType === "tollFree")?"searchTollFree":"searchLocal"];
-      delete parameters.numberType;
-      search(this, parameters, callback);
-    },
-    acquirePhoneNumber: function(phoneNumber, callback)
-    {
-      lib.PhoneNumber.create(this, phoneNumber, callback);
-    },
-    getPhoneNumber: function(numberId, callback){
-      lib.PhoneNumber.get(this, numberId, callback);
-    },
-    getPhoneNumbers: function(callback){
-      lib.PhoneNumber.list(this, callback);
-    },
-    deletePhoneNumber: function(numberId, callback){
-      var number = new lib.PhoneNumber();
-      number.id = numberId;
-      number.client = this;
-      number.delete(callback);
-    },
-    updatePhoneNumber:  function(numberId, parameters, callback){
-      var number = new lib.PhoneNumber();
-      number.id = numberId;
-      number.client = this;
-      number.update(parameters, callback);
-    },
-
-    getApplications: function(callback){
-      lib.Application.list(this, callback);
-    },
-
-    checkPortInAvailability: function(availabilityCheck, callback){
-      /*var numberToCheck = {number:availabilityCheck.number}
-      this.get(this.concatUserUrl(portInAvailablePath),null,numberToCheck, function(error, response){
-        if(error){
-          callback(error, null)
-        }else {
-          var availabilityResponses = JSON.parse(response.data)
-          var response = availabilityResponses.length > 0 ? availabilityResponses[0] : null
-          callback(null, response)
-        }
-      })*/
-      callback(new Error("Not supported"));
-    },
-    portIn: function (portInData, callback){
-      /*if(portInData){
-        this.post( this.concatUserUrl(portInPath), portInData, callback )
-      } else {
-        callback( {message:"PortInData object is null"} )
-      }*/
-      callback(new Error("Not supported"));
-    },
-    uploadLOA: function (portInId, filePath, callback){
-      /*if(portInId){
-        this.putFile( this.concatUserUrl(portInPath) + "/" + portInId + "/loas/MyLetter.pdf", filePath, callback )
-      } else {
-        callback( {message:"portInId is null"} )
-      }*/
-      callback(new Error("Not supported"));
-    },
-    cancelPortIn: function (portInId, callback){
-      /*if(portInId){
-        this.post( this.concatUserUrl(portInPath) + "/" + portInId, {state: 'cancelled'}, callback )
-      } else {
-        callback( {message:"portInId is null"} )
-      }*/
-      callback(new Error("Not supported"));
-    },
-    getPortInState: function(portInId, callback){
-      /*if(portInId){
-        this.get(this.concatUserUrl(portInPath) + "/" + portInId,null,null, function(error, response){
-          if(error){
-            ack(error, null)
-          }else {            var resData = JSON.parse(response.data)
-            var err = resData.errors && resData.errors.length > 0 ? resData.errors[0] : null
-            callback(err, resData)
-          }
-        })
-      } else {
-        callback({message:"portInId is null"})
-      }*/
-      callback(new Error("Not supported"));
-    }
-  };
-
-  var k;
-  var mapObsoleteFunction = function(name){
-    lib.Client.prototype[name] = function(){
-      obsolete(name, details[name]);
-      obsoleteFunctions[name].apply(this, arguments);
-    };
-  }
-  Object.keys(obsoleteFunctions).forEach(mapObsoleteFunction);
-
-  //some old types
-  lib.Audio = function(callId){
-    this.callId = callId;
-  };
-  lib.AvailableNumberSearchCriteria = function(){};
-  lib.CallTransfer = function(call, transferTo) {
-    this.call = call;
-    this.transferTo = transferTo;
-    this.whisperAudio = undefined;
-    this.state = "transferring";
-  };
-  lib.LNPAvailabilityCheck = function(number){
-    this.number = number;
-  };
-
-  lib.PortInData = function() {};
+function obsolete(func, detail) {
+	var nodeEnv = process.env.NODE_ENV || "development";
+	if (nodeEnv === "development") {
+		console.warn("Obsolete " + func + "(): Use "  + detail + " instead of it.");
+	}
 }
 
+module.exports = function (lib) {
+	var details = {
+		sendCall                : "Call.create()",
+		changeCall              : "call.update()",
+		startRecording          : "call.recordingOn()",
+		stopRecording           : "call.recordingOff()",
+		getRecording            : "Recording.get()",
+		getRecordings           : "call.getRecordings()",
+		transferCall            : "call.update()",
+		hangUp                  : "call.hangUp()",
+		getCall                 : "Call.get()",
+		playCallAudio           : "call.playAudio()",
+		sendMessage             : "Message.create()",
+		getMessage              : "Message.get()",
+		getMessages             : "Message.list()",
+		getAvailableNumbers     : "AvailableNumber.searchTollFree() or AvailableNumber.searchToLocal()",
+		acquirePhoneNumber      : "PhoneNumber.create()",
+		getPhoneNumber          : "PhoneNumber.get()",
+		getPhoneNumbers         : "PhoneNumber.list()",
+		deletePhoneNumber       : "phoneNumber.delete()",
+		updatePhoneNumber       : "phoneNumber.update()",
+		getApplications         : "Application.list()",
+		portIn                  : "Iris API",
+		uploadLOA               : "Iris API",
+		cancelPortIn            : "Iris API",
+		getPortInState          : "Iris API",
+		checkPortInAvailability : "Iris API"
+	};
 
+	var obsoleteFunctions = {
+		sendCall : function (call, callback) {
+			lib.Call.create(this, call, callback);
+		},
 
+		changeCall : function (callId, data, callback) {
+			var call = new lib.Call();
+			call.id = callId;
+			call.client = this;
+			call.update(data, callback);
+		},
 
+		hangUp : function (callId, callback) {
+			this.changeCall(callId, { state : "completed" }, callback);
+		},
 
+		startRecording : function (callId, callback) {
+			this.changeCall(callId, { recordingEnabled : true }, callback);
+		},
+
+		stopRecording :  function (callId, callback) {
+			this.changeCall(callId, { recordingEnabled : false }, callback);
+		},
+
+		getRecording : function (recordingId, callback) {
+			lib.Recording.get(this, recordingId, callback);
+		},
+
+		getRecordings : function (callId, callback) {
+			var call = new lib.Call();
+			call.id = callId;
+			call.client = this;
+			call.getRecordings(callback);
+		},
+
+		transferCall : function (callTransfer, callback) {
+			var callId = callTransfer.call.id;
+			delete callTransfer.call;
+			var call = new lib.Call();
+			call.id = callId;
+			call.client = this;
+			call.update(callTransfer, callback);
+		},
+
+		getCall : function (callId, callback) {
+			lib.Call.get(this, callId, callback);
+		},
+
+		playCallAudio : function (callAudio, callback) {
+			var callId = callAudio.callId;
+			delete callAudio.callId;
+			var call = new lib.Call();
+			call.id = callId;
+			call.client = this;
+			call.playAudio(callAudio, callback);
+		},
+
+		sendMessage : function (message, callback) {
+			lib.Message.create(this, message, callback);
+		},
+
+		getMessage : function (messageId, callback) {
+			lib.Message.get(this, messageId, callback);
+		},
+
+		getMessages : function (callback) {
+			lib.Message.list(this, callback);
+		},
+
+		getAvailableNumbers : function (parameters, callback) {
+			var search = lib.AvailableNumber[(parameters.numberType === "tollFree")?"searchTollFree":"searchLocal"];
+			delete parameters.numberType;
+			search(this, parameters, callback);
+		},
+
+		acquirePhoneNumber : function (phoneNumber, callback) {
+			lib.PhoneNumber.create(this, phoneNumber, callback);
+		},
+
+		getPhoneNumber : function (numberId, callback) {
+			lib.PhoneNumber.get(this, numberId, callback);
+		},
+
+		getPhoneNumbers : function (callback) {
+			lib.PhoneNumber.list(this, callback);
+		},
+
+		deletePhoneNumber : function (numberId, callback) {
+			var number = new lib.PhoneNumber();
+			number.id = numberId;
+			number.client = this;
+			number.delete(callback);
+		},
+
+		updatePhoneNumber :  function (numberId, parameters, callback) {
+			var number = new lib.PhoneNumber();
+			number.id = numberId;
+			number.client = this;
+			number.update(parameters, callback);
+		},
+
+		getApplications : function (callback) {
+			lib.Application.list(this, callback);
+		},
+
+		checkPortInAvailability : function (availabilityCheck, callback) {
+			callback(new Error("Not supported"));
+		},
+
+		portIn : function (portInData, callback) {
+			callback(new Error("Not supported"));
+		},
+
+		uploadLOA : function (portInId, filePath, callback) {
+			callback(new Error("Not supported"));
+		},
+
+		cancelPortIn : function (portInId, callback) {
+			callback(new Error("Not supported"));
+		},
+
+		getPortInState : function (portInId, callback) {
+			callback(new Error("Not supported"));
+		}
+	};
+
+	var mapObsoleteFunction = function (name) {
+		lib.Client.prototype[name] = function () {
+			obsolete(name, details[name]);
+			obsoleteFunctions[name].apply(this, arguments);
+		};
+	};
+
+	Object.keys(obsoleteFunctions).forEach(mapObsoleteFunction);
+
+	//some old types
+	lib.Audio = function (callId) {
+		this.callId = callId;
+	};
+
+	lib.AvailableNumberSearchCriteria = function () {};
+
+	lib.CallTransfer = function (call, transferTo) {
+		this.call = call;
+		this.transferTo = transferTo;
+		this.whisperAudio = undefined;
+		this.state = "transferring";
+	};
+
+	lib.LNPAvailabilityCheck = function (number) {
+		this.number = number;
+	};
+
+	lib.PortInData = function () {};
+};

--- a/lib/conference.js
+++ b/lib/conference.js
@@ -1,161 +1,186 @@
 "use strict";
+
 var Client = require("./client");
 var ConferenceMember = require("./conferenceMember");
 var CONFERENCE_PATH = "conferences";
 
-function Conference(){
+function Conference() {
 }
 
-/** Retrieve conference information.
+/**
+ * Retrieve conference information.
  * @param client Client instance
  * @param id id of conference
  * @param callback callback function
  * @example
  * bandwidth.Conference.get(client, "id", function(err, conference){});
- * */
-Conference.get = function(client, id, callback){
-  if(arguments.length === 2){
-    callback = id;
-    id = client;
-    client = new Client();
-  }
-  client.makeRequest("get", client.concatUserPath(CONFERENCE_PATH) + "/" +  id, function(err, item){
-    if(err){
-      return callback(err);
-    }
-    item.client = client;
-    item.__proto__ = Conference.prototype;
-    callback(null, item);
-  });
+ */
+Conference.get = function (client, id, callback) {
+	if (arguments.length === 2) {
+		callback = id;
+		id = client;
+		client = new Client();
+	}
+
+	client.makeRequest("get", client.concatUserPath(CONFERENCE_PATH) + "/" +  id, function (err, item) {
+		if (err) {
+			return callback(err);
+		}
+
+		item.client = client;
+		item.__proto__ = Conference.prototype;
+		callback(null, item);
+	});
 };
 
-/** Create a conference.
+/**
+ * Create a conference.
  * @param client Client instance
- * @param item conference's data
+ * @param item conference"s data
  * @param callback callback function
  * @example
- * bandwidth.Conference.create(client, {from: "number"}, function(err, conference){});*/
-Conference.create = function(client, item, callback){
-  if(arguments.length === 2){
-    callback = item;
-    item = client;
-    client = new Client();
-  }
-  var request = client.createRequest("post", client.concatUserPath(CONFERENCE_PATH));
-  request.type("json").send(item).end(function(res){
-    if(res.ok && res.headers.location){
-      Client.getIdFromLocationHeader(res.headers.location, function(err, id){
-        if(err){
-          return callback(err);
-        }
-        Conference.get(client, id, callback);
-      });
-    }
-    else{
-      client.checkResponse(res, callback);
-    }
-  });
+ * bandwidth.Conference.create(client, {from: "number"}, function(err, conference){});
+ */
+Conference.create = function (client, item, callback) {
+	if (arguments.length === 2) {
+		callback = item;
+		item = client;
+		client = new Client();
+	}
+
+	var request = client.createRequest("post", client.concatUserPath(CONFERENCE_PATH));
+	request.type("json").send(item).end(function (res) {
+		if (res.ok && res.headers.location) {
+			Client.getIdFromLocationHeader(res.headers.location, function (err, id) {
+				if (err) {
+					return callback(err);
+				}
+
+				Conference.get(client, id, callback);
+			});
+		}
+		else {
+			client.checkResponse(res, callback);
+		}
+	});
 };
 
-/** Update Conference.
+/**
+ * Update Conference.
  * @param data changed data
  * @param callback callback
  * @example
  * conference.update({mute: false}, function(err){});
- * */
-Conference.prototype.update = function(data, callback){
-  this.client.makeRequest("post", this.client.concatUserPath(CONFERENCE_PATH) + "/" + this.id,  data, callback);
+ */
+Conference.prototype.update = function (data, callback) {
+	this.client.makeRequest("post", this.client.concatUserPath(CONFERENCE_PATH) + "/" + this.id,  data, callback);
 };
 
-/** Complete a conference
+/**
+ * Complete a conference
  * @example
  * conference.complete(function(err){});
  */
-Conference.prototype.complete = function(callback){
-  this.update({state: "completed"}, callback);
+Conference.prototype.complete = function (callback) {
+	this.update({ state : "completed" }, callback);
 };
 
-/** Mute a conference
+/**
+ * Mute a conference
  * @example
- * conference.mute(function(err){});*/
-Conference.prototype.mute = function(callback){
-  this.update({mute: true}, callback);
+ * conference.mute(function(err){});
+ */
+Conference.prototype.mute = function (callback) {
+	this.update({ mute : true }, callback);
 };
 
-/** List all members from a conference.
+/**
+ * List all members from a conference.
  * @example
- * conference.getMembers(function(err, list){});*/
-Conference.prototype.getMembers = function(callback){
-  var client = this.client;
-  var id = this.id;
-  client.makeRequest("get", client.concatUserPath(CONFERENCE_PATH) + "/" + id + "/members", function(err, items){
-    if(err){
-      return callback(err);
-    }
-    items = items || [];
-    var result = items.map(function(item){
-      item.client = client;
-      item.__proto__ = ConferenceMember.prototype;
-      item.conferenceId = id;
-      return item;
-    });
-    callback(null, result);
-  });
+ * conference.getMembers(function(err, list){});
+ */
+Conference.prototype.getMembers = function (callback) {
+	var client = this.client;
+	var id = this.id;
+	client.makeRequest("get", client.concatUserPath(CONFERENCE_PATH) + "/" + id + "/members", function (err, items) {
+		if (err) {
+			return callback(err);
+		}
+
+		items = items || [];
+		var result = items.map(function (item) {
+			item.client = client;
+			item.__proto__ = ConferenceMember.prototype;
+			item.conferenceId = id;
+			return item;
+		});
+
+		callback(null, result);
+	});
 };
 
-/** Retrieve information about a particular conference member.
+/**
+ * Retrieve information about a particular conference member.
  * @param memberId Id of member
  * @param callback callback function
  * @example
  * conference.getMember("1", function(err, member){});
- * */
-Conference.prototype.getMember = function(memberId, callback){
-  var client = this.client;
+ */
+Conference.prototype.getMember = function (memberId, callback) {
+	var client = this.client;
 
-  var id = this.id;
-  client.makeRequest("get", client.concatUserPath(CONFERENCE_PATH) + "/" + id + "/members/" + memberId, function(err, item){
-    if(err){
-      return callback(err);
-    }
-    item.client = client;
-    item.__proto__ = ConferenceMember.prototype;
-    item.conferenceId = id;
-    callback(null, item);
-  });
+	var id = this.id;
+
+	client.makeRequest("get", client.concatUserPath(CONFERENCE_PATH) + "/" + id +
+		"/members/" + memberId, function (err, item) {
+		if (err) {
+			return callback(err);
+		}
+
+		item.client = client;
+		item.__proto__ = ConferenceMember.prototype;
+		item.conferenceId = id;
+		callback(null, item);
+	});
 };
 
-/** Add a member to a conference.
+/**
+ * Add a member to a conference.
  * @param item data to add member to this conference
  * @param callback callback
  * @example
  * conference.createMember({callId: "id"}, function(err,member){});
- * */
-Conference.prototype.createMember = function(item, callback){
-  var self = this;
-  var request = self.client.createRequest("post", self.client.concatUserPath(CONFERENCE_PATH) + "/" + self.id + "/members");
-  request.type("json").send(item).end(function(res){
-    if(res.ok && res.headers.location){
-      Client.getIdFromLocationHeader(res.headers.location, function(err, id){
-        if(err){
-          return callback(err);
-        }
-        self.getMember(id, callback);
-      });
-    }
-    else{
-      self.client.checkResponse(res, callback);
-    }
-  });
+ */
+Conference.prototype.createMember = function (item, callback) {
+	var self = this;
+	var request = self.client.createRequest("post", self.client.concatUserPath(CONFERENCE_PATH) +
+		"/" + self.id + "/members");
+	request.type("json").send(item).end(function (res) {
+		if (res.ok && res.headers.location) {
+			Client.getIdFromLocationHeader(res.headers.location, function (err, id) {
+				if (err) {
+					return callback(err);
+				}
+
+				self.getMember(id, callback);
+			});
+		}
+		else {
+			self.client.checkResponse(res, callback);
+		}
+	});
 };
 
-/** Play an audio/speak a sentence in the conference.
+/**
+ * Play an audio/speak a sentence in the conference.
  * @param data  audio data
  * @param callback callback function
  * @example
  * conference.playAudio({fileUrl: "http://host1"}, function(err){});
- * */
-Conference.prototype.playAudio = function(data, callback){
-  this.client.makeRequest("post", this.client.concatUserPath(CONFERENCE_PATH) + "/" + this.id + "/audio", data, callback);
+ */
+Conference.prototype.playAudio = function (data, callback) {
+	this.client.makeRequest("post", this.client.concatUserPath(CONFERENCE_PATH) + "/" +
+		this.id + "/audio", data, callback);
 };
 
 module.exports = Conference;

--- a/lib/conferenceMember.js
+++ b/lib/conferenceMember.js
@@ -1,25 +1,31 @@
 "use strict";
-function ConferenceMember(){}
+
+function ConferenceMember() {}
 
 var CONFERENCE_PATH = "conferences";
 
-/** Update a conference member. E.g.: remove from call, mute, hold, etc.
+/**
+ * Update a conference member. E.g.: remove from call, mute, hold, etc.
  * @param data changed data
  * @param callback callback function
  * @example
  * conferenceMember.update({mute: true}, function(err){});
- * */
-ConferenceMember.prototype.update = function(data, callback){
-  this.client.makeRequest("post", this.client.concatUserPath(CONFERENCE_PATH) + "/" + this.conferenceId + "/members/" + this.id, data, callback);
+ */
+ConferenceMember.prototype.update = function (data, callback) {
+	var path = this.client.concatUserPath(CONFERENCE_PATH) + "/" + this.conferenceId + "/members/" + this.id;
+	this.client.makeRequest("post", path, data, callback);
 };
 
-/** Play an audio/speak a sentence to a conference member.
+/**
+ * Play an audio/speak a sentence to a conference member.
  * @param data audio data
  * @param callback callback function
  * @example
  * conferenceMember.playAudio({fileUrl: "http://host1"}, function(err){});
- * */
-ConferenceMember.prototype.playAudio = function(data, callback){
-  this.client.makeRequest("post", this.client.concatUserPath(CONFERENCE_PATH) + "/" + this.conferenceId + "/members/" + this.id + "/audio", data, callback);
+ */
+ConferenceMember.prototype.playAudio = function (data, callback) {
+	var path = this.client.concatUserPath(CONFERENCE_PATH) + "/" + this.conferenceId + "/members/" + this.id + "/audio";
+	this.client.makeRequest("post", path, data, callback);
 };
+
 module.exports = ConferenceMember;

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -1,156 +1,176 @@
 "use strict";
+
 var Client = require("./client");
 var EndPoint = require("./endPoint");
 var DOMAIN_PATH = "domains";
 
-function Domain(){
+function Domain() {
 }
 
-/** Retrieve created domain.
+/**
+ * Retrieve created domain.
  * @param client Client instance
  * @param callback callback function
  * @example
  * bandwidth.Domain.list(client,  function(err, domains){});
- * */
-Domain.list = function(client, callback){
-  if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-  }
-  client.makeRequest("get", client.concatUserPath(DOMAIN_PATH), function(err, items){
-    if(err){
-      return callback(err);
-    }
-    items = items || [];
-    items.forEach(function(item){
-      item.client = client;
-      item.__proto__ = Domain.prototype;
-    });
-    callback(null, items);
-  });
+ */
+Domain.list = function (client, callback) {
+	if (arguments.length === 1) {
+		callback = client;
+		client = new Client();
+	}
+
+	client.makeRequest("get", client.concatUserPath(DOMAIN_PATH), function (err, items) {
+		if (err) {
+			return callback(err);
+		}
+
+		items = items || [];
+		items.forEach(function (item) {
+			item.client = client;
+			item.__proto__ = Domain.prototype;
+		});
+
+		callback(null, items);
+	});
 };
 
-/** Create a domain.
+/**
+ * Create a domain.
  * @param client Client instance
- * @param item domain's data
+ * @param item domain"s data
  * @param callback callback function
  * @example
- * bandwidth.Domain.create(client, {name: "domain1"}, function(err, domain){});*/
-Domain.create = function(client, item, callback){
-  if(arguments.length === 2){
-    callback = item;
-    item = client;
-    client = new Client();
-  }
-  var request = client.createRequest("post", client.concatUserPath(DOMAIN_PATH));
-  request.type("json").send(item).end(function(res){
-    if(res.ok && res.headers.location){
-      Client.getIdFromLocationHeader(res.headers.location, function(err, id){
-        if(err){
-          return callback(err);
-        }
-        var domain = new Domain();
-        domain.id = id;
-        domain.client = client;
-        domain.name = item.name;
-        domain.description = item.description;
-        callback(null, domain);
-      });
-    }
-    else{
-      client.checkResponse(res, callback);
-    }
-  });
+ * bandwidth.Domain.create(client, {name: "domain1"}, function(err, domain){});
+ */
+Domain.create = function (client, item, callback) {
+	if (arguments.length === 2) {
+		callback = item;
+		item = client;
+		client = new Client();
+	}
+
+	var request = client.createRequest("post", client.concatUserPath(DOMAIN_PATH));
+	request.type("json").send(item).end(function (res) {
+		if (res.ok && res.headers.location) {
+			Client.getIdFromLocationHeader(res.headers.location, function (err, id) {
+				if (err) {
+					return callback(err);
+				}
+
+				var domain = new Domain();
+				domain.id = id;
+				domain.client = client;
+				domain.name = item.name;
+				domain.description = item.description;
+				callback(null, domain);
+			});
+		}
+		else {
+			client.checkResponse(res, callback);
+		}
+	});
 };
 
-/** Delete a domain.
+/**
+ * Delete a domain.
  * @param callback callback
  * @example
  * domain.delete(function(err){});
- * */
-Domain.prototype.delete = function(callback){
-  this.client.makeRequest("del", this.client.concatUserPath(DOMAIN_PATH) + "/" + this.id,  callback);
+ */
+Domain.prototype.delete = function (callback) {
+	this.client.makeRequest("del", this.client.concatUserPath(DOMAIN_PATH) + "/" + this.id,  callback);
 };
 
-
-/** List endpoints of a domain.
+/**
+ * List endpoints of a domain.
  * @example
- * domain.getEndPoints(function(err, list){});*/
-Domain.prototype.getEndPoints = function(callback){
-  var client = this.client;
-  var id = this.id;
-  client.makeRequest("get", client.concatUserPath(DOMAIN_PATH) + "/" + id + "/endpoints", function(err, items){
-    if(err){
-      return callback(err);
-    }
-    items = items || [];
-    var result = items.map(function(item){
-      item.client = client;
-      item.__proto__ = EndPoint.prototype;
-      item.domainId = id;
-      return item;
-    });
-    callback(null, result);
-  });
+ * domain.getEndPoints(function(err, list){});
+ */
+Domain.prototype.getEndPoints = function (callback) {
+	var client = this.client;
+	var id = this.id;
+	client.makeRequest("get", client.concatUserPath(DOMAIN_PATH) + "/" + id + "/endpoints", function (err, items) {
+		if (err) {
+			return callback(err);
+		}
+
+		items = items || [];
+		var result = items.map(function (item) {
+			item.client = client;
+			item.__proto__ = EndPoint.prototype;
+			item.domainId = id;
+			return item;
+		});
+
+		callback(null, result);
+	});
 };
 
-/** Retrieve information about a particular endpoint of a domain.
+/**
+ * Retrieve information about a particular endpoint of a domain.
  * @param endpointId Id of endpoint
  * @param callback callback function
  * @example
  * domain.getEndPoint("1", function(err, point){});
- * */
-Domain.prototype.getEndPoint = function(endpointId, callback){
-  var client = this.client;
+ */
+Domain.prototype.getEndPoint = function (endpointId, callback) {
+	var client = this.client;
 
-  var id = this.id;
-  client.makeRequest("get", client.concatUserPath(DOMAIN_PATH) + "/" + id + "/endpoints/" + endpointId, function(err, item){
-    if(err){
-      return callback(err);
-    }
-    item.client = client;
-    item.__proto__ = EndPoint.prototype;
-    item.domainId = id;
-    callback(null, item);
-  });
+	var id = this.id;
+	client.makeRequest("get", client.concatUserPath(DOMAIN_PATH) + "/" + id + "/endpoints/" +
+		endpointId, function (err, item) {
+		if (err) {
+			return callback(err);
+		}
+
+		item.client = client;
+		item.__proto__ = EndPoint.prototype;
+		item.domainId = id;
+		callback(null, item);
+	});
 };
 
-/** Add a endpoint to a domain.
+/**
+ * Add a endpoint to a domain.
  * @param item data to add endpoint to this domain
  * @param callback callback
  * @example
  * domain.createEndPoint({applicationId: "id", name: "name"}, function(err,point){});
- * */
-Domain.prototype.createEndPoint = function(item, callback){
-  var self = this;
-  var request = self.client.createRequest("post", self.client.concatUserPath(DOMAIN_PATH) + "/" + self.id + "/endpoints");
-  request.type("json").send(item).end(function(res){
-    if(res.ok && res.headers.location){
-      Client.getIdFromLocationHeader(res.headers.location, function(err, id){
-        if(err){
-          return callback(err);
-        }
-        self.getEndPoint(id, callback);
-      });
-    }
-    else{
-      self.client.checkResponse(res, callback);
-    }
-  });
+ */
+Domain.prototype.createEndPoint = function (item, callback) {
+	var self = this;
+	var request = self.client.createRequest("post", self.client.concatUserPath(DOMAIN_PATH) +
+		"/" + self.id + "/endpoints");
+	request.type("json").send(item).end(function (res) {
+		if (res.ok && res.headers.location) {
+			Client.getIdFromLocationHeader(res.headers.location, function (err, id) {
+				if (err) {
+					return callback(err);
+				}
+
+				self.getEndPoint(id, callback);
+			});
+		}
+		else {
+			self.client.checkResponse(res, callback);
+		}
+	});
 };
 
-/** Delete an endpoint
+/**
+ * Delete an endpoint
  * @param endpointId Id of endpoint to remove
  * @param callback callback
  * @example
  * domain.deleteEndPoint("id", function(err){});
- * */
-Domain.prototype.deleteEndPoint = function(endpointId, callback){
-  var item = new EndPoint();
-  item.client = this.client;
-  item.id = endpointId;
-  item.domainId = this.id;
-  item.delete(callback);
+ */
+Domain.prototype.deleteEndPoint = function (endpointId, callback) {
+	var item = new EndPoint();
+	item.client = this.client;
+	item.id = endpointId;
+	item.domainId = this.id;
+	item.delete(callback);
 };
 
 module.exports = Domain;

--- a/lib/endPoint.js
+++ b/lib/endPoint.js
@@ -1,36 +1,41 @@
 "use strict";
-var Client = require("./client");
+
 var DOMAIN_PATH = "domains";
 var ENDPOINT_PATH = "endpoints";
 
-function EndPoint(){
+function EndPoint() {
 }
 
-/** Delete a endPoint.
+/**
+ * Delete a endPoint.
  * @param callback callback
  * @example
  * endPoint.delete(function(err){});
- * */
-EndPoint.prototype.delete = function(callback){
-  this.client.makeRequest("del", this.client.concatUserPath(DOMAIN_PATH) + "/" + this.domainId + "/" + ENDPOINT_PATH + "/" + this.id,  callback);
+ */
+EndPoint.prototype.delete = function (callback) {
+	var path =  this.client.concatUserPath(DOMAIN_PATH) + "/" + this.domainId + "/" + ENDPOINT_PATH + "/" + this.id;
+	this.client.makeRequest("del", path, callback);
 };
 
-/** Create an auth token
-* @param callback callback
-* @example
-* endPoint.createAuthToken(function(err, token){})
-*/
-EndPoint.prototype.createAuthToken = function(callback){
-  var self = this;
-  var request = self.client.createRequest("post", this.client.concatUserPath(DOMAIN_PATH) + "/" + this.domainId + "/" + ENDPOINT_PATH + "/" + this.id + "/tokens");
-  request.type("json").send(null).end(function(res){
-    if(res.ok){
-    	callback(null, res.body);
-    }
-    else{
-      self.client.checkResponse(res, callback);
-    }
-  });
+/**
+ * Create an auth token
+ * @param callback callback
+ * @example
+ * endPoint.createAuthToken(function(err, token){})
+ */
+EndPoint.prototype.createAuthToken = function (callback) {
+	var self = this;
+	var path = this.client.concatUserPath(DOMAIN_PATH) + "/" + this.domainId + "/" +
+		ENDPOINT_PATH + "/" + this.id + "/tokens";
+	var request = self.client.createRequest("post", path);
+	request.type("json").send(null).end(function (res) {
+		if (res.ok) {
+			callback(null, res.body);
+		}
+		else {
+			self.client.checkResponse(res, callback);
+		}
+	});
 };
 
 module.exports = EndPoint;

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,47 +1,51 @@
 "use strict";
+
 var Client = require("./client");
 var ERROR_PATH = "errors";
 
 module.exports = {
-  /** Gets information about one user error
-   *  @param client Client instance
-   *  @param id Id of error
-   *  @param callback callback
-   *  @example
-   *  bandwidth.Error.get(client, "id", function(err, errorData){});
-   * */
-  get: function(client, id, callback){
-    if(arguments.length === 2){
-      callback = id;
-      id = client;
-      client = new Client();
-    }
-    client.makeRequest("get", client.concatUserPath(ERROR_PATH) + "/" + id, callback);
-  },
-  /** Gets all the user errors for a user
-   * @param client Client instance
-   * @param query query parameters
-   * @param callback callback
-   * @example
-   * bandwidth.Error.list(client, function(err, list){});
-   * */
-  list: function(client, query, callback){
-    if(arguments.length === 1){
-      callback = client;
-      client = new Client();
-    }
-    if(arguments.length === 2){
-      callback = query;
-      if(client instanceof Client){
-        query = {};
-      }
-      else{
-        query = client;
-        client = new Client();
-      }
-    }
-    client.makeRequest("get", client.concatUserPath(ERROR_PATH), query, callback);
-  }
+	/**
+	 * Gets information about one user error
+	 * @param client Client instance
+	 * @param id Id of error
+	 * @param callback callback
+	 * @example
+	 * bandwidth.Error.get(client, "id", function(err, errorData){});
+	 */
+	get : function (client, id, callback) {
+		if (arguments.length === 2) {
+			callback = id;
+			id = client;
+			client = new Client();
+		}
+
+		client.makeRequest("get", client.concatUserPath(ERROR_PATH) + "/" + id, callback);
+	},
+
+	/** Gets all the user errors for a user
+	 * @param client Client instance
+	 * @param query query parameters
+	 * @param callback callback
+	 * @example
+	 * bandwidth.Error.list(client, function(err, list){});
+	 */
+	list : function (client, query, callback) {
+		if (arguments.length === 1) {
+			callback = client;
+			client = new Client();
+		}
+
+		if (arguments.length === 2) {
+			callback = query;
+			if (client instanceof Client) {
+				query = {};
+			}
+			else {
+				query = client;
+				client = new Client();
+			}
+		}
+
+		client.makeRequest("get", client.concatUserPath(ERROR_PATH), query, callback);
+	}
 };
-
-

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -2,18 +2,18 @@
 var util = require("util");
 /** Error type */
 function BandwidthError(message, httpStatus){
-  this.message = message;
-  this.httpStatus = httpStatus;
+	this.message = message;
+	this.httpStatus = httpStatus;
 }
 util.inherits(BandwidthError, Error);
 
 function MissingCredentialsError(){
-  this.message = "Missing credentials.\n" +
-                "Use new Client(<userId>, <apiToken>, <apiSecret>) or Client.globalOptions to set up them.";
+	this.message = "Missing credentials.\n" +
+	"Use new Client(<userId>, <apiToken>, <apiSecret>) or Client.globalOptions to set up them.";
 }
 util.inherits(MissingCredentialsError, Error);
 
 module.exports = {
-  BandwidthError: BandwidthError,
-  MissingCredentialsError: MissingCredentialsError
+	BandwidthError          : BandwidthError,
+	MissingCredentialsError : MissingCredentialsError
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,13 +1,13 @@
 "use strict";
 var util = require("util");
 /** Error type */
-function BandwidthError(message, httpStatus){
+function BandwidthError(message, httpStatus) {
 	this.message = message;
 	this.httpStatus = httpStatus;
 }
 util.inherits(BandwidthError, Error);
 
-function MissingCredentialsError(){
+function MissingCredentialsError() {
 	this.message = "Missing credentials.\n" +
 	"Use new Client(<userId>, <apiToken>, <apiSecret>) or Client.globalOptions to set up them.";
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,23 +1,23 @@
 "use strict";
 module.exports = {
-  Client: require("./client"),
-  Call: require("./call"),
-  Account: require("./account"),
-  Application: require("./application"),
-  AvailableNumber: require("./availableNumber"),
-  Bridge: require("./bridge"),
-  Conference: require("./conference"),
-  ConferenceMember: require("./conferenceMember"),
-  Domain: require("./domain"),
-  EndPoint: require("./endPoint"),
-  Error: require("./error"),
-  Media: require("./media"),
-  Message: require("./message"),
-  NumberInfo: require("./numberInfo"),
-  PhoneNumber: require("./phoneNumber"),
-  Recording: require("./recording"),
-  xml: require("./xml"),
-  errors: require("./errors")
+	Client           : require("./client"),
+	Call             : require("./call"),
+	Account          : require("./account"),
+	Application      : require("./application"),
+	AvailableNumber  : require("./availableNumber"),
+	Bridge           : require("./bridge"),
+	Conference       : require("./conference"),
+	ConferenceMember : require("./conferenceMember"),
+	Domain           : require("./domain"),
+	EndPoint         : require("./endPoint"),
+	Error            : require("./error"),
+	Media            : require("./media"),
+	Message          : require("./message"),
+	NumberInfo       : require("./numberInfo"),
+	PhoneNumber      : require("./phoneNumber"),
+	Recording        : require("./recording"),
+	xml              : require("./xml"),
+	errors           : require("./errors")
 };
 
 require("./compatibility")(module.exports);

--- a/lib/media.js
+++ b/lib/media.js
@@ -1,161 +1,181 @@
 "use strict";
+
 var Client = require("./client");
 var fs = require("fs");
 var errors = require("./errors");
 var MEDIA_PATH = "media";
 
-function sendFile(request, file, mediaType, callback){
-  var stream = null;
-  request.buffer().type(mediaType || "application/octet-stream");
-  if(typeof file === "string"){
-    stream = fs.createReadStream(file);
-  }
-  else if(Buffer.isBuffer(file)){
-    request.write(file);
-    request.end(callback);
-    return;
-  }
-  else if(typeof file.pipe === "function" && typeof file.read === "function" && typeof file.on === "function"){
-    stream = file;
-  }
-  if(stream){
-    request.on("response", callback);
-    stream.pipe(request);
-    return;
-  }
-  callback({statusCode: 400, text: "Invalid data to send", body: {message: "Invalid data to send"}});
+function sendFile(request, file, mediaType, callback) {
+	var stream = null;
+	request.buffer().type(mediaType || "application/octet-stream");
+	if (typeof file === "string") {
+		stream = fs.createReadStream(file);
+	}
+	else if (Buffer.isBuffer(file)) {
+		request.write(file);
+		request.end(callback);
+		return;
+	}
+	else if (typeof file.pipe === "function" && typeof file.read === "function" && typeof file.on === "function") {
+		stream = file;
+	}
+
+	if (stream) {
+		request.on("response", callback);
+		stream.pipe(request);
+		return;
+	}
+
+	callback({ statusCode : 400, text : "Invalid data to send", body : { message : "Invalid data to send" } });
 }
 
-
 module.exports = {
-  /** Get a list of your media files
-   * @param client Client instance
-   * @param query query parameters
-   * @param callback callback function
-   * @example
-   * bandwidth.Media.list(client, function(err, list){});
-   * */
-  list: function(client, query, callback){
-    if(arguments.length === 1){
-      callback = client;
-      client = new Client();
-    }
-    else if(arguments.length === 2){
-      callback = query;
-      if(client instanceof Client){
-        query = {};
-      }
-      else{
-        query = client;
-        client = new Client();
-      }
-    }
-    client.makeRequest("get", client.concatUserPath(MEDIA_PATH), query, callback);
-  },
+	/**
+	 * Get a list of your media files
+	 * @param client Client instance
+	 * @param query query parameters
+	 * @param callback callback function
+	 * @example
+	 * bandwidth.Media.list(client, function(err, list){});
+	 */
+	list : function (client, query, callback) {
+		if (arguments.length === 1) {
+			callback = client;
+			client = new Client();
+		}
+		else if (arguments.length === 2) {
+			callback = query;
+			if (client instanceof Client) {
+				query = {};
+			}
+			else {
+				query = client;
+				client = new Client();
+			}
+		}
 
-  /** Uploads a media file (or stream, or buffer) to the name you choose
-   * @param client Client instance
-   * @param name file name
-   * @param mediaTypr media type of file
-   * @param callback callback function
-   * @example
-   * bandwidth.Media.upload(client, "file.pdf", stream, "application/pdf", function(err){});
-   * */
-  upload: function(client, name, data, mediaType, callback){
-    if(arguments.length === 3){
-      callback = data;
-      data = name;
-      name = client;
-      client = new Client();
-      mediaType = null;
-    }
-    else if(arguments.length === 4){
-      callback = mediaType;
-      if(client instanceof Client){
-        mediaType = null;
-      }
-      else{
-        mediaType = data;
-        data = name;
-        name = client;
-        client = new Client();
-      }
-    }
-    var request = client.createRequest("put", client.concatUserPath(MEDIA_PATH) + "/" + encodeURIComponent(name));
-    sendFile(request, data, mediaType, function(res){
-      client.checkResponse(res, callback);
-    });
-  },
-  /** Downloads a media file you uploaded to given destination(file or stream)
-   * @param client Client instance
-   * @param name file name
-   * @param destination file name or stream to write downloaded file
-   * @returns request object
-   * @example
-   * bandwidth.Media.download(client, "file1.pdf", "/tmp/file1.pdf").end(function(err, res){});
-   * */
-  download: function(client, name, destination){
-    if(arguments.length <= 2){
-      if(client instanceof Client){
-        destination = null;
-      }
-      else{
-        destination = name;
-        name = client;
-        client = new Client();
-      }
-    }
-    var request = client.createRequest("get", client.concatUserPath(MEDIA_PATH) + "/" + encodeURIComponent(name));
-    if(destination){
-      var stream = null;
-      if(typeof destination === "string"){
-        stream = fs.createWriteStream(destination);
-      }
-      else if(typeof destination.write === "function"){
-        stream = destination;
-      }
-      if(stream){
-        return request.pipe(stream);
-      }
-    }
-    return request;
-  },
-  /** Permanently deletes a media file you uploaded
-   * @param client Client instance
-   * @param name file name
-   * @param callback callback function
-   * @example
-   * bandwidth.delete(client, "file1.pdf", function(err){});
-   * */
-  delete: function(client, name, callback){
-    if(arguments.length === 2){
-      callback = name;
-      name = client;
-      client = new Client();
-    }
-    client.makeRequest("del", client.concatUserPath(MEDIA_PATH) + "/" + encodeURIComponent(name), callback);
-  },
+		client.makeRequest("get", client.concatUserPath(MEDIA_PATH), query, callback);
+	},
 
-  /** Get information about a media file
-   *
-   * @param client Client instance
-   * @param name file name
-   * @param callback
-   * @example
-   * bandwidth.Media.getInfo(client, "file1.wav", function(err, res){});
-   * */
-  getInfo: function(client, name, callback){
-    if(arguments.length === 2){
-      callback = name;
-      name = client;
-      client = new Client();
-    }
-    var request = client.createRequest("head", client.concatUserPath(MEDIA_PATH) + "/" + encodeURIComponent(name));
-    request.end( function (err, res){
-      if(res.ok){
-        return callback( null, { contentType: res.get("content-type"), contentLength: res.get("content-length")});
-      }
-      return callback(new errors.BandwidthError("Http code " + res.status, res.status));
-    });
-  }
+	/**
+	 * Uploads a media file (or stream, or buffer) to the name you choose
+	 * @param client Client instance
+	 * @param name file name
+	 * @param mediaTypr media type of file
+	 * @param callback callback function
+	 * @example
+	 * bandwidth.Media.upload(client, "file.pdf", stream, "application/pdf", function(err){});
+	 */
+	upload : function (client, name, data, mediaType, callback) {
+		if (arguments.length === 3) {
+			callback = data;
+			data = name;
+			name = client;
+			client = new Client();
+			mediaType = null;
+		}
+		else if (arguments.length === 4) {
+			callback = mediaType;
+			if (client instanceof Client) {
+				mediaType = null;
+			}
+			else {
+				mediaType = data;
+				data = name;
+				name = client;
+				client = new Client();
+			}
+		}
+
+		var request = client.createRequest("put", client.concatUserPath(MEDIA_PATH) + "/" + encodeURIComponent(name));
+		sendFile(request, data, mediaType, function (res) {
+			client.checkResponse(res, callback);
+		});
+	},
+
+	/**
+	 * Downloads a media file you uploaded to given destination(file or stream)
+	 * @param client Client instance
+	 * @param name file name
+	 * @param destination file name or stream to write downloaded file
+	 * @returns request object
+	 * @example
+	 * bandwidth.Media.download(client, "file1.pdf", "/tmp/file1.pdf").end(function(err, res){});
+	 */
+	download : function (client, name, destination) {
+		if (arguments.length <= 2) {
+			if (client instanceof Client) {
+				destination = null;
+			}
+			else {
+				destination = name;
+				name = client;
+				client = new Client();
+			}
+		}
+
+		var request = client.createRequest("get", client.concatUserPath(MEDIA_PATH) + "/" + encodeURIComponent(name));
+		if (destination) {
+			var stream = null;
+			if (typeof destination === "string") {
+				stream = fs.createWriteStream(destination);
+			}
+			else if (typeof destination.write === "function") {
+				stream = destination;
+			}
+
+			if (stream) {
+				return request.pipe(stream);
+			}
+		}
+
+		return request;
+	},
+
+	/**
+	 * Permanently deletes a media file you uploaded
+	 * @param client Client instance
+	 * @param name file name
+	 * @param callback callback function
+	 * @example
+	 * bandwidth.delete(client, "file1.pdf", function(err){});
+	 */
+	delete : function (client, name, callback) {
+		if (arguments.length === 2) {
+			callback = name;
+			name = client;
+			client = new Client();
+		}
+
+		client.makeRequest("del", client.concatUserPath(MEDIA_PATH) + "/" + encodeURIComponent(name), callback);
+	},
+
+	/**
+	 * Get information about a media file
+	 * @param client Client instance
+	 * @param name file name
+	 * @param callback
+	 * @example
+	 * bandwidth.Media.getInfo(client, "file1.wav", function(err, res){});
+	 */
+	getInfo : function (client, name, callback) {
+		if (arguments.length === 2) {
+			callback = name;
+			name = client;
+			client = new Client();
+		}
+
+		var request = client.createRequest("head", client.concatUserPath(MEDIA_PATH) + "/" + encodeURIComponent(name));
+		request.end(function (err, res) {
+			if (res.ok) {
+				return callback(null,
+					{
+						contentType   : res.get("content-type"),
+						contentLength : res.get("content-length")
+					});
+			}
+
+			return callback(new errors.BandwidthError("Http code " + res.status, res.status));
+		});
+	}
 };

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,119 +1,133 @@
 "use strict";
+
 var Client = require("./client");
 var MESSAGE_PATH = "messages";
 
-function Message(){
-  //compabtibility fix
-  if(arguments.length > 0){
-    this.from = arguments[0];
-    this.to = arguments[1];
-    this.text = arguments[2];
-  }
+function Message() {
+	//compabtibility fix
+	if (arguments.length > 0) {
+		this.from = arguments[0];
+		this.to = arguments[1];
+		this.text = arguments[2];
+	}
 }
 
-/** Get information about a message that was sent or received
+/**
+ * Get information about a message that was sent or received
  * @param client Client instance
  * @param id id of Message
  * @param callback callback
  * @example
  * bandwidth.Message.get(client, "id", function(err, message){});
- * */
-Message.get = function(client, id, callback){
-  if(arguments.length === 2){
-    callback = id;
-    id = client;
-    client = new Client();
-  }
-  client.makeRequest("get", client.concatUserPath(MESSAGE_PATH) + "/" +  id, function(err, item){
-    if(err){
-      return callback(err);
-    }
-    item.client = client;
-    item.__proto__ = Message.prototype;
-    callback(null, item);
-  });
+ */
+Message.get = function (client, id, callback) {
+	if (arguments.length === 2) {
+		callback = id;
+		id = client;
+		client = new Client();
+	}
+
+	client.makeRequest("get", client.concatUserPath(MESSAGE_PATH) + "/" +  id, function (err, item) {
+		if (err) {
+			return callback(err);
+		}
+
+		item.client = client;
+		item.__proto__ = Message.prototype;
+		callback(null, item);
+	});
 };
 
-/** Get a list of previous messages that were sent or received
+/**
+ * Get a list of previous messages that were sent or received
  * @param client Client instance
  * @param query query parameters
  * @param callback callback function
  * @example
  * bandwidth.Message.list(client, function(err, list){});
- * */
-Message.list = function(client, query, callback){
-  if(arguments.length === 2){
-    callback = query;
-    if(client instanceof Client){
-      query = {};
-    }
-    else{
-      query = client;
-      client = new Client();
-    }
-  }
-  else if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-  }
-  client.makeRequest("get", client.concatUserPath(MESSAGE_PATH), query, function(err, items){
-    if(err){
-      return callback(err);
-    }
-    items = items || [];
-    var result = items.map(function(item){
-      item.client = client;
-      item.__proto__ = Message.prototype;
-      return item;
-    });
-    callback(null, result);
-  });
+ */
+Message.list = function (client, query, callback) {
+	if (arguments.length === 2) {
+		callback = query;
+		if (client instanceof Client) {
+			query = {};
+		}
+		else {
+			query = client;
+			client = new Client();
+		}
+	}
+	else if (arguments.length === 1) {
+		callback = client;
+		client = new Client();
+	}
+
+	client.makeRequest("get", client.concatUserPath(MESSAGE_PATH), query, function (err, items) {
+		if (err) {
+			return callback(err);
+		}
+
+		items = items || [];
+		var result = items.map(function (item) {
+			item.client = client;
+			item.__proto__ = Message.prototype;
+			return item;
+		});
+
+		callback(null, result);
+	});
 };
 
-/** Send text messages
+/**
+ * Send text messages
  * @param client Client instance
  * @param item message (or list of messages) to send
  * @param callback callback function
  * @example
  * bandwidth.Message.create(client, {from: "", to: "", text: ""}, function(err, message){});
  * bandwidth.Message.create(client, [{from: "", to: "", text: ""}], function(err, statuses){});
- * */
-Message.create = function(client, item, callback){
-  if(arguments.length === 2){
-    callback = item;
-    item = client;
-    client = new Client();
-  }
-  var isList = Array.isArray(item);
-  var request = client.createRequest("post", client.concatUserPath(MESSAGE_PATH));
-  request.type("json").send(item).end(function(res){
-    if(res.ok){
-      if(isList){
-        var statuses = (res.body || []).map(function(i){
-          if(i.result === "error"){
-            return {error: new Error(i.error.message)};
-          }
-          var index = (i.location || "").lastIndexOf("/");
-          if(index < 0){
-            return {error: new Error("Missing id in response")};
-          }
-          return {id: i.location.substr(index + 1)};
-        });
-        callback(null, statuses);
-      }
-      else{
-        Client.getIdFromLocationHeader(res.headers.location || "", function(err, id){
-          if(err){
-            return callback(err);
-          }
-          Message.get(client, id, callback);
-        });
-      }
-    }
-    else{
-      client.checkResponse(res, callback);
-    }
-  });
+ */
+Message.create = function (client, item, callback) {
+	if (arguments.length === 2) {
+		callback = item;
+		item = client;
+		client = new Client();
+	}
+
+	var isList = Array.isArray(item);
+	var request = client.createRequest("post", client.concatUserPath(MESSAGE_PATH));
+	request.type("json").send(item).end(function (res) {
+		if (res.ok) {
+			if (isList) {
+				var statuses = (res.body || []).map(function (i) {
+					if (i.result === "error") {
+						return { error : new Error(i.error.message) };
+					}
+
+					var index = (i.location || "").lastIndexOf("/");
+					if (index < 0) {
+						return { error : new Error("Missing id in response") };
+					}
+
+					return { id : i.location.substr(index + 1) };
+				});
+
+				callback(null, statuses);
+			}
+			else {
+				Client.getIdFromLocationHeader(res.headers.location || "", function (err, id) {
+					if (err) {
+						return callback(err);
+					}
+
+					Message.get(client, id, callback);
+				});
+			}
+		}
+		else {
+			client.checkResponse(res, callback);
+		}
+	});
 };
 
 module.exports = Message;

--- a/lib/numberInfo.js
+++ b/lib/numberInfo.js
@@ -1,23 +1,23 @@
 "use strict";
+
 var Client = require("./client");
 var NUMBER_INFO_PATH = "phoneNumbers/numberInfo";
 
 module.exports = {
-  /** Get the CNAM info of a number
-   * @param client Client instance
-   * @param number Phone number
-   * @param callback callback function
-   * @example
-   * bandwidth.NumberInfo.get(client, "number", function(err, info){});
-   * */
-  get: function(client, number, callback){
-    if(arguments.length === 2){
-      callback = number;
-      number = client;
-      client = new Client();
-    }
-    client.makeRequest("get", NUMBER_INFO_PATH + "/" + encodeURIComponent(number), callback);
-  }
+	/** Get the CNAM info of a number
+	 * @param client Client instance
+	 * @param number Phone number
+	 * @param callback callback function
+	 * @example
+	 * bandwidth.NumberInfo.get(client, "number", function(err, info){});
+	 */
+	get : function (client, number, callback) {
+		if (arguments.length === 2) {
+			callback = number;
+			number = client;
+			client = new Client();
+		}
+
+		client.makeRequest("get", NUMBER_INFO_PATH + "/" + encodeURIComponent(number), callback);
+	}
 };
-
-

--- a/lib/phoneNumber.js
+++ b/lib/phoneNumber.js
@@ -1,120 +1,133 @@
 "use strict";
+
 var Client = require("./client");
 var PHONE_NUMBER_PATH = "phoneNumbers";
 
-function PhoneNumber(){
-  //for compatibility only
-  if(arguments.length > 0){
-    this.number = arguments[0];
-    this.name = arguments[1];
-    this.applicationId = arguments[2];
-  }
+function PhoneNumber() {
+	//for compatibility only
+	if (arguments.length > 0) {
+		this.number = arguments[0];
+		this.name = arguments[1];
+		this.applicationId = arguments[2];
+	}
 }
 
-/** Get information about one number
+/**
+ * Get information about one number
  * @param client Client instance
  * @param id Id of phone number
  * @param callback callback function
  * @example
  * bandwidth.PhoneNumber.get(client, "id", function(err, number){});
- * */
-PhoneNumber.get = function(client, id, callback){
-  if(arguments.length === 2){
-    callback = id;
-    id = client;
-    client = new Client();
-  }
-  client.makeRequest("get", client.concatUserPath(PHONE_NUMBER_PATH) + "/" +  id, function(err, item){
-    if(err){
-      return callback(err);
-    }
-    item.client = client;
-    item.__proto__ = PhoneNumber.prototype;
-    callback(null, item);
-  });
+ */
+PhoneNumber.get = function (client, id, callback) {
+	if (arguments.length === 2) {
+		callback = id;
+		id = client;
+		client = new Client();
+	}
+
+	client.makeRequest("get", client.concatUserPath(PHONE_NUMBER_PATH) + "/" +  id, function (err, item) {
+		if (err) {
+			return callback(err);
+		}
+
+		item.client = client;
+		item.__proto__ = PhoneNumber.prototype;
+		callback(null, item);
+	});
 };
 
-/** Get a list of your numbers
+/**
+ * Get a list of your numbers
  * @param client Client instance
  * @param query query parameters
  * @param callback callback function
  * @example
  * bandwidth.PhoneNumber.list(client, function(err, list){});
  */
-PhoneNumber.list = function(client, query, callback){
-  if(arguments.length === 2){
-    callback = query;
-    if(client instanceof Client){
-      query = {};
-    }
-    else{
-      query = client;
-      client = new Client();
-    }
-  }
-  else if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-  }
-  client.makeRequest("get", client.concatUserPath(PHONE_NUMBER_PATH), query, function(err, items){
-    if(err){
-      return callback(err);
-    }
-    items = items || [];
-    var result = items.map(function(item){
-      item.client = client;
-      item.__proto__ = PhoneNumber.prototype;
-      return item;
-    });
-    callback(null, result);
-  });
+PhoneNumber.list = function (client, query, callback) {
+	if (arguments.length === 2) {
+		callback = query;
+		if (client instanceof Client) {
+			query = {};
+		}
+		else {
+			query = client;
+			client = new Client();
+		}
+	}
+	else if (arguments.length === 1) {
+		callback = client;
+		client = new Client();
+	}
+
+	client.makeRequest("get", client.concatUserPath(PHONE_NUMBER_PATH), query, function (err, items) {
+		if (err) {
+			return callback(err);
+		}
+
+		items = items || [];
+		var result = items.map(function (item) {
+			item.client = client;
+			item.__proto__ = PhoneNumber.prototype;
+			return item;
+		});
+
+		callback(null, result);
+	});
 };
 
-/** Allocate a number so you can use it
+/**
+ * Allocate a number so you can use it
  * @param client Client instance
  * @param item data to create phone number
  * @param callback callback function
  * @example
  * bandwidth.PhoneNumber.create(client, {number: "number"}, function(err, number){});
- * */
-PhoneNumber.create = function(client, item, callback){
-  if(arguments.length === 2){
-    callback = item;
-    item = client;
-    client = new Client();
-  }
-  var request = client.createRequest("post", client.concatUserPath(PHONE_NUMBER_PATH));
-  request.type("json").send(item).end(function(res){
-    if(res.ok && res.headers.location){
-      Client.getIdFromLocationHeader(res.headers.location, function(err, id){
-        if(err){
-          return callback(err);
-        }
-        PhoneNumber.get(client, id, callback);
-      });
-    }
-    else{
-      client.checkResponse(res, callback);
-    }
-  });
+ */
+PhoneNumber.create = function (client, item, callback) {
+	if (arguments.length === 2) {
+		callback = item;
+		item = client;
+		client = new Client();
+	}
+
+	var request = client.createRequest("post", client.concatUserPath(PHONE_NUMBER_PATH));
+	request.type("json").send(item).end(function (res) {
+		if (res.ok && res.headers.location) {
+			Client.getIdFromLocationHeader(res.headers.location, function (err, id) {
+				if (err) {
+					return callback(err);
+				}
+
+				PhoneNumber.get(client, id, callback);
+			});
+		}
+		else {
+			client.checkResponse(res, callback);
+		}
+	});
 };
 
-/** Make changes to a number you have
+/**
+ * Make changes to a number you have
  * @param data changed data
  * @param callback callback
  * @example
  * number.update({name: "new name"}, function(err){});
- * */
-PhoneNumber.prototype.update = function(data, callback){
-  this.client.makeRequest("post", this.client.concatUserPath(PHONE_NUMBER_PATH) + "/" + this.id,  data, callback);
+ */
+PhoneNumber.prototype.update = function (data, callback) {
+	this.client.makeRequest("post", this.client.concatUserPath(PHONE_NUMBER_PATH) + "/" + this.id,  data, callback);
 };
 
-/** Remove a number from your account
+/**
+ * Remove a number from your account
  * @example
  * number.delete(function(err){});
- * */
-PhoneNumber.prototype.delete = function(callback){
-  this.client.makeRequest("del", this.client.concatUserPath(PHONE_NUMBER_PATH) + "/" + this.id, callback);
+ */
+PhoneNumber.prototype.delete = function (callback) {
+	this.client.makeRequest("del", this.client.concatUserPath(PHONE_NUMBER_PATH) + "/" + this.id, callback);
 };
 
 module.exports = PhoneNumber;

--- a/lib/recording.js
+++ b/lib/recording.js
@@ -1,104 +1,120 @@
 "use strict";
+
 var Client = require("./client");
 var RECORDING_PATH = "recordings";
 
-function Recording(){
+function Recording() {
 }
 
-/** Retrieve a specific call recording information, identified by recordingId
+/**
+ * Retrieve a specific call recording information, identified by recordingId
  * @param client Client instance
  * @param id Id of recording
  * @param callback callback
  * @example
  * bandwidth.Recording.get(client, "id", function(err, recording){});
- * */
-Recording.get = function(client, id, callback){
-  if(arguments.length === 2){
-    callback = id;
-    id = client;
-    client = new Client();
-  }
-  client.makeRequest("get", client.concatUserPath(RECORDING_PATH) + "/" +  id, function(err, item){
-    if(err){
-      return callback(err);
-    }
-    item.client = client;
-    item.__proto__ = Recording.prototype;
-    callback(null, item);
-  });
+ */
+Recording.get = function (client, id, callback) {
+	if (arguments.length === 2) {
+		callback = id;
+		id = client;
+		client = new Client();
+	}
+
+	client.makeRequest("get", client.concatUserPath(RECORDING_PATH) + "/" +  id, function (err, item) {
+		if (err) {
+			return callback(err);
+		}
+
+		item.client = client;
+		item.__proto__ = Recording.prototype;
+		callback(null, item);
+	});
 };
 
-/** List a user's call recordings
+/**
+ * List a user"s call recordings
  * @param client Client instance
  * @param query query parameters
  * @param callback callback
  * @example
  * bandwidth.Recording.list(client, function(err, list){});
- * */
-Recording.list = function(client, query, callback){
-  if(arguments.length === 2){
-    callback = query;
-    if(client instanceof Client){
-      query = {};
-    }
-    else{
-      query = client;
-      client = new Client();
-    }
-  }
-  else if(arguments.length === 1){
-    callback = client;
-    client = new Client();
-  }
-  client.makeRequest("get", client.concatUserPath(RECORDING_PATH), query, function(err, items){
-    if(err){
-      return callback(err);
-    }
-    callback(null, (items || []).map(function(item){
-      item.client = client;
-      item.__proto__ = Recording.prototype;
-      return item;
-    }));
-  });
+ */
+Recording.list = function (client, query, callback) {
+	if (arguments.length === 2) {
+		callback = query;
+		if (client instanceof Client) {
+			query = {};
+		}
+		else {
+			query = client;
+			client = new Client();
+		}
+	}
+	else if (arguments.length === 1) {
+		callback = client;
+		client = new Client();
+	}
+
+	client.makeRequest("get", client.concatUserPath(RECORDING_PATH), query, function (err, items) {
+		if (err) {
+			return callback(err);
+		}
+
+		callback(null, (items || []).map(function (item) {
+			item.client = client;
+			item.__proto__ = Recording.prototype;
+			return item;
+		}));
+	});
 
 };
-/** Request the transcription process to be started for the given recording id.
+
+/**
+ * Request the transcription process to be started for the given recording id.
  * @param callback callback function
  * @example
  * recording.createTranscription(function(err, transcription){})
- * */
-Recording.prototype.createTranscription = function(callback){
-  var self = this;
-  var request = self.client.createRequest("post", self.client.concatUserPath(RECORDING_PATH) + "/" + this.id + "/transcriptions");
-  request.type("json").send({}).end(function(res){
-    if(res.ok && res.headers.location){
-      Client.getIdFromLocationHeader(res.headers.location, function(err, id){
-        if(err){
-          return callback(err);
-        }
-        self.getTranscription(id, callback);
-      });
-    }
-    else{
-      self.client.checkResponse(res, callback);
-    }
-  });
+ */
+Recording.prototype.createTranscription = function (callback) {
+	var self = this;
+	var request = self.client.createRequest("post", self.client.concatUserPath(RECORDING_PATH) +
+		"/" + this.id + "/transcriptions");
+	request.type("json").send({}).end(function (res) {
+		if (res.ok && res.headers.location) {
+			Client.getIdFromLocationHeader(res.headers.location, function (err, id) {
+				if (err) {
+					return callback(err);
+				}
+
+				self.getTranscription(id, callback);
+			});
+		}
+		else {
+			self.client.checkResponse(res, callback);
+		}
+	});
 };
 
-/** Gets information about a transcription
+/**
+ * Gets information about a transcription
  * @param transcriptionId Id of event
  * @param callback callback function
  * @example
- * recording.getTranscription("id", function(err, transcription){});*/
-Recording.prototype.getTranscription = function(transcriptionId, callback){
-  this.client.makeRequest("get", this.client.concatUserPath(RECORDING_PATH + "/" + this.id + "/transcriptions/" + transcriptionId), callback);
+ * recording.getTranscription("id", function(err, transcription){});
+ */
+Recording.prototype.getTranscription = function (transcriptionId, callback) {
+	var path = this.client.concatUserPath(RECORDING_PATH + "/" + this.id + "/transcriptions/" + transcriptionId);
+	this.client.makeRequest("get", path, callback);
 };
 
 /** Gets the list of all transcriptions
  * @example
- * recording.getTranscriptions(function(err, list){});*/
-Recording.prototype.getTranscriptions = function(callback){
-  this.client.makeRequest("get", this.client.concatUserPath(RECORDING_PATH + "/" + this.id + "/transcriptions"), callback);
+ * recording.getTranscriptions(function(err, list){});
+ */
+Recording.prototype.getTranscriptions = function (callback) {
+	this.client.makeRequest("get", this.client.concatUserPath(RECORDING_PATH +
+			"/" + this.id + "/transcriptions"), callback);
 };
 
 module.exports = Recording;

--- a/lib/xml.js
+++ b/lib/xml.js
@@ -1,212 +1,255 @@
 "use strict";
+
 var builder = require("xmlbuilder");
 
-/** Response type (root object) */
-function Response(verbs){
-  this.verbs = verbs || [];
+/**
+ * Response type (root object)
+ * @param {[type]} verbs [description]
+ */
+function Response(verbs) {
+	this.verbs = verbs || [];
 }
 
-/** Build xml string from resposne */
-Response.prototype.toXml = function(){
-  var response = {};
-  if(this.verbs.length > 0){
-    response["#list"] = this.verbs.map(function(v){return v.toXmlObject();});
-  }
-  var root = {"Response": response};
-  return builder.create(root).end({pretty: true});
+/**
+ * Build xml string from resposne
+ * @return {[type]} [description]
+ */
+Response.prototype.toXml = function () {
+	var response = {};
+	if (this.verbs.length > 0) {
+		response["#list"] = this.verbs.map(function (v) {
+			return v.toXmlObject();
+		});
+	}
+
+	var root = { "Response" : response };
+	return builder.create(root).end({ pretty : true });
 };
 
-/** Add a verb to response */
-Response.prototype.push = function(verb){
-  this.verbs.push(verb);
+/**
+ * Add a verb to response
+ * @param  {[type]} verb [description]
+ * @return {[type]}      [description]
+ */
+Response.prototype.push = function (verb) {
+	this.verbs.push(verb);
 };
 
-function copyTo(data){
-  var k;
-  if(data){
-    for(k in data){
-      this[k] = data[k];
-    }
-  }
+function copyTo(source, destination) {
+	if (source) {
+		for (var k in source) {
+			destination[k] = source[k];
+		}
+	}
 }
 
-function removeEmptyKeys(obj){
-  var result = {}, k, v;
-  for(k in obj){
-    v = obj[k];
-    if(v){
-      result[k] = (typeof v === "object")?removeEmptyKeys(v):v;
-    }
-  }
-  return result;
+function removeEmptyKeys(obj) {
+	var result = {};
+	var k;
+	var v;
+	for (k in obj) {
+		v = obj[k];
+		if (v) {
+			result[k] = (typeof v === "object")?removeEmptyKeys(v):v;
+		}
+	}
+
+	return result;
 }
 
-
-/** Gather verb */
-function Gather(data){
-  copyTo.call(this, data);
+/**
+ * Gather verb
+ * @param {[type]} data [description]
+ */
+function Gather(data) {
+	copyTo(data, this);
 }
 
-Gather.prototype.toXmlObject = function(){
-  debugger;
-  return removeEmptyKeys({
-   "Gather": {
-     "@requestUrl": this.requestUrl,
-     "@requestUrlTimeout": this.requestUrlTimeout,
-     "@terminatingDigits": this.terminatingDigits,
-     "@maxDigits": this.maxDigits,
-     "@interDigitTimeout": this.interDigitTimeout,
-     "@bargeable": this.bargeable
-    }
- });
+Gather.prototype.toXmlObject = function () {
+	return removeEmptyKeys({
+		"Gather" : {
+			"@requestUrl"        : this.requestUrl,
+			"@requestUrlTimeout" : this.requestUrlTimeout,
+			"@terminatingDigits" : this.terminatingDigits,
+			"@maxDigits"         : this.maxDigits,
+			"@interDigitTimeout" : this.interDigitTimeout,
+			"@bargeable"         : this.bargeable
+		}
+	});
 };
 
-
-/** Hangup verb*/
-function Hangup(){
+/**
+ * Hangup verb
+ */
+function Hangup() {
 }
 
-Hangup.prototype.toXmlObject = function(){
-  return {"Hangup": {}};
+Hangup.prototype.toXmlObject = function () {
+	return { "Hangup" : {} };
 };
 
-
-/** Pause verb */
-function Pause(data){
-  copyTo.call(this, data);
+/**
+ * Pause verb
+ * @param {[type]} data [description]
+ */
+function Pause(data) {
+	copyTo(data, this);
 }
 
-Pause.prototype.toXmlObject = function(){
-  return removeEmptyKeys({
-    "Pause":{
-      "@duration": this.duration
-    }
-  });
+Pause.prototype.toXmlObject = function () {
+	return removeEmptyKeys({
+		"Pause" : {
+			"@duration" : this.duration
+		}
+	});
 };
 
-/** PlayAudio verb */
-function PlayAudio(data){
-  copyTo.call(this, data);
+/**
+ * PlayAudio verb
+ * @param {[type]} data [description]
+ */
+function PlayAudio(data) {
+	copyTo(data, this);
 }
 
-PlayAudio.prototype.toXmlObject = function(){
-  return removeEmptyKeys({
-    "PlayAudio":{
-      "@digits": this.digits,
-      "#text": this.url
-    }
-  });
+PlayAudio.prototype.toXmlObject = function () {
+	return removeEmptyKeys({
+		"PlayAudio" : {
+			"@digits" : this.digits,
+			"#text"   : this.url
+		}
+	});
 };
 
-/** Record verb */
-function Record(data){
-  copyTo.call(this, data);
+/**
+ * Record verb
+ * @param {[type]} data [description]
+ */
+function Record(data) {
+	copyTo(data, this);
 }
 
-Record.prototype.toXmlObject = function(){
-  return removeEmptyKeys({
-    "Record":{
-      "@requestUrl": this.requestUrl,
-      "@requestUrlTimeout": this.requestUrlTimeout,
-      "@terminatingDigits": this.terminatingDigits,
-      "@maxDuration": this.maxDuration,
-      "@transcribe": this.transcribe,
-      "@transcribeCallbackUrl": this.transcribeCallbackUrl
-    }
-  });
+Record.prototype.toXmlObject = function () {
+	return removeEmptyKeys({
+		"Record" : {
+			"@requestUrl"            : this.requestUrl,
+			"@requestUrlTimeout"     : this.requestUrlTimeout,
+			"@terminatingDigits"     : this.terminatingDigits,
+			"@maxDuration"           : this.maxDuration,
+			"@transcribe"            : this.transcribe,
+			"@transcribeCallbackUrl" : this.transcribeCallbackUrl
+		}
+	});
 };
 
-/** Redirect verb */
-function Redirect(data){
-  copyTo.call(this, data);
+/**
+ * Redirect verb
+ * @param {[type]} data [description]
+ */
+function Redirect(data) {
+	copyTo(data, this);
 }
 
-Redirect.prototype.toXmlObject = function(){
-  return removeEmptyKeys({
-    "Redirect":{
-      "@requestUrl": this.requestUrl,
-      "@requestUrlTimeout": this.requestUrlTimeout
-    }
-  });
+Redirect.prototype.toXmlObject = function () {
+	return removeEmptyKeys({
+		"Redirect" : {
+			"@requestUrl"        : this.requestUrl,
+			"@requestUrlTimeout" : this.requestUrlTimeout
+		}
+	});
 };
 
-/** Reject verb */
-function Reject(data){
-  copyTo.call(this, data);
+/**
+ * Reject verb
+ * @param {[type]} data [description]
+ */
+function Reject(data) {
+	copyTo(data, this);
 }
 
-Reject.prototype.toXmlObject = function(){
-  return removeEmptyKeys({
-    "Reject":{
-      "@reason": this.reason
-    }
-  });
+Reject.prototype.toXmlObject = function () {
+	return removeEmptyKeys({
+		"Reject" : {
+			"@reason" : this.reason
+		}
+	});
 };
 
-/** SendMessage verb */
-function SendMessage(data){
-  copyTo.call(this, data);
+/**
+ * SendMessage verb
+ * @param {[type]} data [description]
+ */
+function SendMessage(data) {
+	copyTo(data, this);
 }
 
-SendMessage.prototype.toXmlObject = function(){
-  return removeEmptyKeys({
-    "SendMessage":{
-      "@from": this.from,
-      "@to": this.to,
-      "@requestUrl": this.requestUrl,
-      "@requestUrlTimeout": this.requestUrlTimeout,
-      "@statusCallbackUrl": this.statusCallbackUrl,
-      "#text": this.text
-    }
-  });
+SendMessage.prototype.toXmlObject = function () {
+	return removeEmptyKeys({
+		"SendMessage" : {
+			"@from"              : this.from,
+			"@to"                : this.to,
+			"@requestUrl"        : this.requestUrl,
+			"@requestUrlTimeout" : this.requestUrlTimeout,
+			"@statusCallbackUrl" : this.statusCallbackUrl,
+			"#text"              : this.text
+		}
+	});
 };
 
-/** SpeakSentence verb */
-function SpeakSentence(data){
-  copyTo.call(this, data);
+/**
+ * SpeakSentence verb
+ * @param {[type]} data [description]
+ */
+function SpeakSentence(data) {
+	copyTo(data, this);
 }
 
-SpeakSentence.prototype.toXmlObject = function(){
-  return removeEmptyKeys({
-    "SpeakSentence":{
-      "@voice": this.voice,
-      "@locale": this.locale,
-      "@gender": this.gender,
-      "#text": this.sentence
-    }
-  });
+SpeakSentence.prototype.toXmlObject = function () {
+	return removeEmptyKeys({
+		"SpeakSentence" : {
+			"@voice"  : this.voice,
+			"@locale" : this.locale,
+			"@gender" : this.gender,
+			"#text"   : this.sentence
+		}
+	});
 };
 
-/** Transfer verb */
-function Transfer(data){
-  copyTo.call(this, data);
+/**
+ * Transfer verb
+ * @param {[type]} data [description]
+ */
+function Transfer(data) {
+	copyTo(data, this);
 }
 
-Transfer.prototype.toXmlObject = function(){
-  var speakSentence;
-  if(this.speakSentence){
-    speakSentence = ((this.speakSentence instanceof SpeakSentence)?this.speakSentence:new SpeakSentence(this.speakSentence))
-      .toXmlObject()["SpeakSentence"];
-  }
-  return removeEmptyKeys({
-    "Transfer":{
-      "@transferTo": this.transferTo,
-      "@transferCallerId": this.transferCallerId,
-      "SpeakSentence": speakSentence
-    }
-  });
+Transfer.prototype.toXmlObject = function () {
+	var speakSentence;
+	if (this.speakSentence) {
+		speakSentence = ((this.speakSentence instanceof SpeakSentence) ?
+			this.speakSentence : new SpeakSentence(this.speakSentence))
+			.toXmlObject().SpeakSentence;
+	}
+
+	return removeEmptyKeys({
+		"Transfer" : {
+			"@transferTo"       : this.transferTo,
+			"@transferCallerId" : this.transferCallerId,
+			"SpeakSentence"     : speakSentence
+		}
+	});
 };
 
 module.exports = {
-  Response: Response,
-  Gather: Gather,
-  Hangup: Hangup,
-  Pause: Pause,
-  PlayAudio: PlayAudio,
-  Record: Record,
-  Redirect: Redirect,
-  Reject: Reject,
-  SendMessage: SendMessage,
-  SpeakSentence: SpeakSentence,
-  Transfer: Transfer
+	Response      : Response,
+	Gather        : Gather,
+	Hangup        : Hangup,
+	Pause         : Pause,
+	PlayAudio     : PlayAudio,
+	Record        : Record,
+	Redirect      : Redirect,
+	Reject        : Reject,
+	SendMessage   : SendMessage,
+	SpeakSentence : SpeakSentence,
+	Transfer      : Transfer
 };

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "node-bandwidth",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "NodeJs Client library for Catapult API",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_ENV=test ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha"
+    "test": "NODE_ENV=test gulp"
   },
   "repository": {
     "type": "git",
@@ -26,7 +26,13 @@
   },
   "devDependencies": {
     "async": "^0.9.0",
-    "istanbul": "^0.3.2",
+    "gulp": "^3.9.0",
+    "gulp-clean": "^0.3.1",
+    "gulp-istanbul": "^0.10.0",
+    "gulp-jscs": "^1.6.0",
+    "gulp-jshint": "^1.11.0",
+    "gulp-mocha": "^2.1.1",
+    "jshint-stylish": "^2.0.0",
     "mocha": "^2.0.1",
     "nock": "^0.50.0",
     "should": "4.3.0"

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,12 @@
+{
+	"node": true,
+	"expr": true,
+	"globals": {
+		"describe": false,
+		"it": false,
+		"before": false,
+		"beforeEach": false,
+		"after": false,
+		"afterEach": false
+	}
+}

--- a/test/account.js
+++ b/test/account.js
@@ -3,85 +3,98 @@ var helper = require("./helper");
 var nock = require("nock");
 var Account = lib.Account;
 
-describe("Account", function(){
-  before(function(){
-    nock.disableNetConnect();
-    helper.setupGlobalOptions();
-  });
-  after(function(){
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-  describe("#get", function(){
-    var item = {
-      accountType: "prepay",
-      balance: 100,
-    };
-    it("should return account info", function(done){
-      helper.nock().get("/v1/users/FakeUserId/account").reply(200, item);
-      Account.get(helper.createClient(),function(err, i){
-        if(err){
-          return done(err);
-        }
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should return account info (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/account").reply(200, item);
-      Account.get(function(err, i){
-        if(err){
-          return done(err);
-        }
-        i.should.eql(item);
-        done();
-      });
-    });
-  });
-  describe("#getTransaction", function(){
-    var items = [
-      {id: 1, amount: 30, type: "charge"},
-      {id: 2, amount: 20, type: "payment"}
-    ];
-    it("should return transactions", function(done){
-      helper.nock().get("/v1/users/FakeUserId/account/transactions?page=1").reply(200, items);
-      Account.getTransactions(helper.createClient(), {page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return transactions (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/account/transactions?page=1").reply(200, items);
-      Account.getTransactions({page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return transactions (without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/account/transactions").reply(200, items);
-      Account.getTransactions(helper.createClient(), function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return transactions (with default client, without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/account/transactions").reply(200, items);
-      Account.getTransactions(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-  });
+describe("Account", function () {
+
+	before(function () {
+		nock.disableNetConnect();
+		helper.setupGlobalOptions();
+	});
+
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	describe("#get", function () {
+		var item = {
+			accountType : "prepay",
+			balance     : 100
+		};
+
+		it("should return account info", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/account").reply(200, item);
+			Account.get(helper.createClient(), function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should return account info (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/account").reply(200, item);
+			Account.get(function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				i.should.eql(item);
+				done();
+			});
+		});
+	});
+
+	describe("#getTransaction", function () {
+		var items = [ { id : 1, amount : 30, type : "charge" },
+			{ id : 2, amount : 20, type : "payment" } ];
+		it("should return transactions", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/account/transactions?page=1").reply(200, items);
+			Account.getTransactions(helper.createClient(), { page : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return transactions (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/account/transactions?page=1").reply(200, items);
+			Account.getTransactions({ page : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return transactions (without query)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/account/transactions").reply(200, items);
+			Account.getTransactions(helper.createClient(), function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return transactions (with default client, without query)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/account/transactions").reply(200, items);
+			Account.getTransactions(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+	});
 });

--- a/test/application.js
+++ b/test/application.js
@@ -1,182 +1,222 @@
+"use strict";
+
 var lib = require("../");
 var helper = require("./helper");
 var nock = require("nock");
 var Application = lib.Application;
 
-describe("Application", function(){
-  before(function(){
-    nock.disableNetConnect();
-    helper.setupGlobalOptions();
-  });
-  after(function(){
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-  describe("#list", function(){
-    var items = [{
-        id: "1",
-        name: "app1",
-        incomingCallUrl: "http://host1"
-      },{
-        id: "2",
-        name: "app2",
-        incomingCallUrl: "http://host2"
-      }
-    ];
-    it("should return list of applications", function(done){
-      helper.nock().get("/v1/users/FakeUserId/applications?page=1").reply(200, items);
-      Application.list(helper.createClient(), {page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of applications (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/applications?page=1").reply(200, items);
-      Application.list({page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of applications (without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/applications").reply(200, items);
-      Application.list(helper.createClient(), function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of applications (with default client, without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/applications").reply(200, items);
-      Application.list(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().get("/v1/users/FakeUserId/applications").reply(500);
-      Application.list(helper.createClient(), {}, function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#get", function(){
-    var item = {
-        id: "1",
-        name: "app1",
-        incomingCallUrl: "http://host1"
-    };
-    it("should return an application", function(done){
-      helper.nock().get("/v1/users/FakeUserId/applications/1").reply(200, item);
-      Application.get(helper.createClient(), "1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should return an application (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/applications/1").reply(200, item);
-      Application.get("1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().get("/v1/users/FakeUserId/applications/1").reply(500);
-      Application.get(helper.createClient(), "1", function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#create", function(){
-    var item = {
-        id: "1",
-        name: "111",
-        incomingCallUrl: "http://host1"
-    };
-    var data = {
-        name: "111",
-        incomingCallUrl: "http://host1"
-    };
-    it("should create an application", function(done){
-      helper.nock().post("/v1/users/FakeUserId/applications", data).reply(201, "", {"Location": "/v1/users/FakeUserId/applications/1"});
-      helper.nock().get("/v1/users/FakeUserId/applications/1").reply(200, item);
-      Application.create(helper.createClient(), data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should create an application (with default client)", function(done){
-      helper.nock().post("/v1/users/FakeUserId/applications", data).reply(201, "", {"Location": "/v1/users/FakeUserId/applications/1"});
-      helper.nock().get("/v1/users/FakeUserId/applications/1").reply(200, item);
-      Application.create(data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().post("/v1/users/FakeUserId/applications").reply(500);
-      Application.create(helper.createClient(), data, function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#update", function(){
-    it("should update an application", function(done){
-      var data = {incomingCallUrl: "http://host2" };
-      helper.nock().post("/v1/users/FakeUserId/applications/1", data).reply(200);
-      var app = new Application();
-      app.id = 1;
-      app.client = helper.createClient();
-      app.update(data, done);
-    });
-  });
+describe("Application", function () {
+	before(function () {
+		nock.disableNetConnect();
+		helper.setupGlobalOptions();
+	});
 
-  describe("#delete", function(){
-    it("should remove an application", function(done){
-      helper.nock().delete("/v1/users/FakeUserId/applications/1").reply(200);
-      var app = new Application();
-      app.id = 1;
-      app.client = helper.createClient();
-      app.delete(done);
-    });
-  });
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	describe("#list", function () {
+		var items = [ {
+			id              : "1",
+			name            : "app1",
+			incomingCallUrl : "http://host1"
+		},{
+			id              : "2",
+			name            : "app2",
+			incomingCallUrl : "http://host2"
+		} ];
+
+		it("should return list of applications", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/applications?page=1").reply(200, items);
+			Application.list(helper.createClient(), { page : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return list of applications (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/applications?page=1").reply(200, items);
+			Application.list({ page : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return list of applications (without query)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/applications").reply(200, items);
+			Application.list(helper.createClient(), function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return list of applications (with default client, without query)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/applications").reply(200, items);
+			Application.list(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/applications").reply(500);
+			Application.list(helper.createClient(), {}, function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#get", function () {
+		var item = {
+			id              : "1",
+			name            : "app1",
+			incomingCallUrl : "http://host1"
+		};
+		it("should return an application", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/applications/1").reply(200, item);
+			Application.get(helper.createClient(), "1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should return an application (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/applications/1").reply(200, item);
+			Application.get("1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/applications/1").reply(500);
+			Application.get(helper.createClient(), "1", function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#create", function () {
+		var item = {
+			id              : "1",
+			name            : "111",
+			incomingCallUrl : "http://host1"
+		};
+		var data = {
+			name            : "111",
+			incomingCallUrl : "http://host1"
+		};
+		it("should create an application", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/applications", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/applications/1" });
+			helper.nock().get("/v1/users/FakeUserId/applications/1").reply(200, item);
+			Application.create(helper.createClient(), data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should create an application (with default client)", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/applications", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/applications/1" });
+			helper.nock().get("/v1/users/FakeUserId/applications/1").reply(200, item);
+			Application.create(data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/applications").reply(500);
+			Application.create(helper.createClient(), data, function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#update", function () {
+		it("should update an application", function (done) {
+			var data = { incomingCallUrl : "http://host2" };
+			helper.nock().post("/v1/users/FakeUserId/applications/1", data).reply(200);
+			var app = new Application();
+			app.id = 1;
+			app.client = helper.createClient();
+			app.update(data, done);
+		});
+	});
+
+	describe("#delete", function () {
+		it("should remove an application", function (done) {
+			helper.nock().delete("/v1/users/FakeUserId/applications/1").reply(200);
+			var app = new Application();
+			app.id = 1;
+			app.client = helper.createClient();
+			app.delete(done);
+		});
+	});
 });

--- a/test/availableNumber.js
+++ b/test/availableNumber.js
@@ -3,116 +3,134 @@ var helper = require("./helper");
 var nock = require("nock");
 var AvailableNumber = lib.AvailableNumber;
 
-describe("AvailableNumber", function(){
-  var items = [{
-    number: "1",
-    city: "City1",
-    lata: "Lata1",
-    nationalNumber: "NationalNumber1",
-    patternMatch: "PatternMatch1",
-    price: 0.01,
-    rateCenter: "RateCenter1",
-    state: "State1"
-  }, {
-    number: "2",
-    city: "City2",
-    lata: "Lata2",
-    nationalNumber: "NationalNumber2",
-    patternMatch: "PatternMatch2",
-    price: 0.02,
-    rateCenter: "RateCenter2",
-    state: "State2"
-  }];
-  before(function(){
-    nock.disableNetConnect();
-    helper.setupGlobalOptions();
-  });
-  after(function(){
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-  describe("#searchTollFree", function(){
-    it("should return numbers", function(done){
-      helper.nock().get("/v1/availableNumbers/tollFree?criteria1=1").reply(200, items);
-      AvailableNumber.searchTollFree(helper.createClient(), {criteria1: 1},function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return numbers (with default client)", function(done){
-      helper.nock().get("/v1/availableNumbers/tollFree?criteria1=1").reply(200, items);
-      AvailableNumber.searchTollFree({criteria1: 1},function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return numbers (without query)", function(done){
-      helper.nock().get("/v1/availableNumbers/tollFree").reply(200, items);
-      AvailableNumber.searchTollFree(helper.createClient(), function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return numbers (with default client, without query)", function(done){
-      helper.nock().get("/v1/availableNumbers/tollFree").reply(200, items);
-      AvailableNumber.searchTollFree(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-  });
-  describe("#searchLocal", function(){
-    it("should return numbers", function(done){
-      helper.nock().get("/v1/availableNumbers/local?criteria1=1").reply(200, items);
-      AvailableNumber.searchLocal(helper.createClient(), {criteria1: 1},function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return numbers (with default client)", function(done){
-      helper.nock().get("/v1/availableNumbers/local?criteria1=1").reply(200, items);
-      AvailableNumber.searchLocal({criteria1: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return numbers (without query)", function(done){
-      helper.nock().get("/v1/availableNumbers/local").reply(200, items);
-      AvailableNumber.searchLocal(helper.createClient(), function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return numbers (with default client, without query)", function(done){
-      helper.nock().get("/v1/availableNumbers/local").reply(200, items);
-      AvailableNumber.searchLocal(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-  });
+describe("AvailableNumber", function () {
+	var items = [ {
+		number         : "1",
+		city           : "City1",
+		lata           : "Lata1",
+		nationalNumber : "NationalNumber1",
+		patternMatch   : "PatternMatch1",
+		price          : 0.01,
+		rateCenter     : "RateCenter1",
+		state          : "State1"
+	}, {
+		number         : "2",
+		city           : "City2",
+		lata           : "Lata2",
+		nationalNumber : "NationalNumber2",
+		patternMatch   : "PatternMatch2",
+		price          : 0.02,
+		rateCenter     : "RateCenter2",
+		state          : "State2"
+	} ];
+
+	before(function () {
+		nock.disableNetConnect();
+		helper.setupGlobalOptions();
+	});
+
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	describe("#searchTollFree", function () {
+		it("should return numbers", function (done) {
+			helper.nock().get("/v1/availableNumbers/tollFree?criteria1=1").reply(200, items);
+			AvailableNumber.searchTollFree(helper.createClient(), { criteria1 : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return numbers (with default client)", function (done) {
+			helper.nock().get("/v1/availableNumbers/tollFree?criteria1=1").reply(200, items);
+			AvailableNumber.searchTollFree({ criteria1 : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return numbers (without query)", function (done) {
+			helper.nock().get("/v1/availableNumbers/tollFree").reply(200, items);
+			AvailableNumber.searchTollFree(helper.createClient(), function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return numbers (with default client, without query)", function (done) {
+			helper.nock().get("/v1/availableNumbers/tollFree").reply(200, items);
+			AvailableNumber.searchTollFree(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+	});
+
+	describe("#searchLocal", function () {
+		it("should return numbers", function (done) {
+			helper.nock().get("/v1/availableNumbers/local?criteria1=1").reply(200, items);
+			AvailableNumber.searchLocal(helper.createClient(), { criteria1 : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return numbers (with default client)", function (done) {
+			helper.nock().get("/v1/availableNumbers/local?criteria1=1").reply(200, items);
+			AvailableNumber.searchLocal({ criteria1 : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return numbers (without query)", function (done) {
+			helper.nock().get("/v1/availableNumbers/local").reply(200, items);
+			AvailableNumber.searchLocal(helper.createClient(), function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return numbers (with default client, without query)", function (done) {
+			helper.nock().get("/v1/availableNumbers/local").reply(200, items);
+			AvailableNumber.searchLocal(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+	});
 });

--- a/test/bridge.js
+++ b/test/bridge.js
@@ -3,184 +3,219 @@ var helper = require("./helper");
 var nock = require("nock");
 var Bridge = lib.Bridge;
 
-describe("Bridge", function(){
-  before(function(){
-    nock.disableNetConnect();
-    helper.setupGlobalOptions();
-  });
-  after(function(){
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-  describe("#list", function(){
-    var items = [{
-        id: "1",
-        state: "active",
-      },{
-        id: "2",
-        state: "active",
-      }
-    ];
-    it("should return list of bridges", function(done){
-      helper.nock().get("/v1/users/FakeUserId/bridges").reply(200, items);
-      Bridge.list(helper.createClient(),  function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of bridges (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/bridges").reply(200, items);
-      Bridge.list(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should fail if request failed", function(done){
-      helper.nock().get("/v1/users/FakeUserId/bridges").reply(500);
-      Bridge.list(helper.createClient(),  function(err, list){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#get", function(){
-    var item = {
-        id: "1",
-        state: "active"
-    };
-    it("should return a bridge", function(done){
-      helper.nock().get("/v1/users/FakeUserId/bridges/1").reply(200, item);
-      Bridge.get(helper.createClient(), "1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should return a bridge (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/bridges/1").reply(200, item);
-      Bridge.get("1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().get("/v1/users/FakeUserId/bridges/1").reply(500);
-      Bridge.get(helper.createClient(), "1", function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#create", function(){
-    var item = {
-        id: "1",
-        state: "active"
-    };
-    var data = {
-        bridge: "call"
-    };
-    it("should create a bridge", function(done){
-      helper.nock().post("/v1/users/FakeUserId/bridges", data).reply(201, "", {"Location": "/v1/users/FakeUserId/bridges/1"});
-      helper.nock().get("/v1/users/FakeUserId/bridges/1").reply(200, item);
-      Bridge.create(helper.createClient(), data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should create a bridge (with default client)", function(done){
-      helper.nock().post("/v1/users/FakeUserId/bridges", data).reply(201, "", {"Location": "/v1/users/FakeUserId/bridges/1"});
-      helper.nock().get("/v1/users/FakeUserId/bridges/1").reply(200, item);
-      Bridge.create(data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().post("/v1/users/FakeUserId/bridges").reply(500);
-      Bridge.create(helper.createClient(), data, function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#update", function(){
-    it("should update a bridge", function(done){
-      var data = {bridge: "call2" };
-      helper.nock().post("/v1/users/FakeUserId/bridges/1", data).reply(200);
-      var bridge = new Bridge();
-      bridge.id = 1;
-      bridge.client = helper.createClient();
-      bridge.update(data, done);
-    });
-  });
+describe("Bridge", function () {
+	before(function () {
+		nock.disableNetConnect();
+		helper.setupGlobalOptions();
+	});
 
-  describe("#playAudio", function(){
-    it("should play audio", function(done){
-      var data = {fileUrl: "http://host1" };
-      helper.nock().post("/v1/users/FakeUserId/bridges/1/audio", data).reply(200);
-      var bridge = new Bridge();
-      bridge.id = 1;
-      bridge.client = helper.createClient();
-      bridge.playAudio(data, done);
-    });
-  });
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
 
-  describe("#getCalls", function(){
-    it("should return bridges of a bridge", function(done){
-      var items = [{id: 1}, {id: 2}];
-      helper.nock().get("/v1/users/FakeUserId/bridges/1/calls").reply(200, items);
-      var bridge = new Bridge();
-      bridge.id = 1;
-      bridge.client = helper.createClient();
-      bridge.getCalls(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should fail if request failed", function(done){
-      helper.nock().get("/v1/users/FakeUserId/bridges/1/calls").reply(500);
-      var bridge = new Bridge();
-      bridge.id = 1;
-      bridge.client = helper.createClient();
-      bridge.getCalls(function(err, list){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
+	describe("#list", function () {
+		var items = [ {
+			id    : "1",
+			state : "active"
+		}, {
+			id    : "2",
+			state : "active"
+		} ];
+
+		it("should return list of bridges", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/bridges").reply(200, items);
+			Bridge.list(helper.createClient(),  function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return list of bridges (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/bridges").reply(200, items);
+			Bridge.list(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should fail if request failed", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/bridges").reply(500);
+			Bridge.list(helper.createClient(),  function (err, list) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#get", function () {
+		var item = {
+			id    : "1",
+			state : "active"
+		};
+		it("should return a bridge", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/bridges/1").reply(200, item);
+			Bridge.get(helper.createClient(), "1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should return a bridge (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/bridges/1").reply(200, item);
+			Bridge.get("1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/bridges/1").reply(500);
+			Bridge.get(helper.createClient(), "1", function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#create", function () {
+		var item = {
+			id    : "1",
+			state : "active"
+		};
+		var data = {
+			bridge : "call"
+		};
+
+		it("should create a bridge", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/bridges", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/bridges/1" });
+			helper.nock().get("/v1/users/FakeUserId/bridges/1").reply(200, item);
+			Bridge.create(helper.createClient(), data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should create a bridge (with default client)", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/bridges", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/bridges/1" });
+			helper.nock().get("/v1/users/FakeUserId/bridges/1").reply(200, item);
+			Bridge.create(data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/bridges").reply(500);
+			Bridge.create(helper.createClient(), data, function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#update", function () {
+		it("should update a bridge", function (done) {
+			var data = { bridge : "call2" };
+			helper.nock().post("/v1/users/FakeUserId/bridges/1", data).reply(200);
+			var bridge = new Bridge();
+			bridge.id = 1;
+			bridge.client = helper.createClient();
+			bridge.update(data, done);
+		});
+	});
+
+	describe("#playAudio", function () {
+		it("should play audio", function (done) {
+			var data = { fileUrl : "http://host1" };
+			helper.nock().post("/v1/users/FakeUserId/bridges/1/audio", data).reply(200);
+			var bridge = new Bridge();
+			bridge.id = 1;
+			bridge.client = helper.createClient();
+			bridge.playAudio(data, done);
+		});
+	});
+
+	describe("#getCalls", function () {
+		it("should return bridges of a bridge", function (done) {
+			var items = [ { id : 1 }, { id : 2 } ];
+			helper.nock().get("/v1/users/FakeUserId/bridges/1/calls").reply(200, items);
+			var bridge = new Bridge();
+			bridge.id = 1;
+			bridge.client = helper.createClient();
+			bridge.getCalls(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should fail if request failed", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/bridges/1/calls").reply(500);
+			var bridge = new Bridge();
+			bridge.id = 1;
+			bridge.client = helper.createClient();
+			bridge.getCalls(function (err, list) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
 });

--- a/test/call.js
+++ b/test/call.js
@@ -1,614 +1,712 @@
 var lib = require("../");
 var helper = require("./helper");
 var nock = require("nock");
-var Call = lib.Call
+var Call = lib.Call;
 
-describe("Call", function(){
-  before(function(){
-    nock.disableNetConnect();
-    helper.setupGlobalOptions();
-  });
-  after(function(){
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-  describe("#list", function(){
-    var items = [{
-        id: "1",
-        from: "111",
-        to: "222",
-        state: "active"
-      },{
-        id: "2",
-        from: "211",
-        to: "322",
-        state: "active"
-      }
-    ];
-    it("should return list of calls", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls?page=1").reply(200, items);
-      Call.list(helper.createClient(), {page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of calls (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls?page=1").reply(200, items);
-      Call.list({page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of calls (without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls").reply(200, items);
-      Call.list(helper.createClient(), function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of calls (with default client, without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls").reply(200, items);
-      Call.list(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls").reply(500);
-      Call.list(helper.createClient(), {}, function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#get", function(){
-    var item = {
-        id: "1",
-        from: "111",
-        to: "222",
-        state: "active"
-    };
-    it("should return a call", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, item);
-      Call.get(helper.createClient(), "1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should return a call (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, item);
-      Call.get("1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(500);
-      Call.get(helper.createClient(), "1", function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#create", function(){
-    var item = {
-        id: "1",
-        from: "111",
-        to: "222",
-        state: "active"
-    };
-    var data = {
-        from: "111",
-        to: "222",
-    };
-    it("should create a call", function(done){
-      helper.nock().post("/v1/users/FakeUserId/calls", data).reply(201, "", {"Location": "/v1/users/FakeUserId/calls/1"});
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, item);
-      Call.create(helper.createClient(), data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should create a  call (with default client)", function(done){
-      helper.nock().post("/v1/users/FakeUserId/calls", data).reply(201, "", {"Location": "/v1/users/FakeUserId/calls/1"});
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, item);
-      Call.create(data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().post("/v1/users/FakeUserId/calls").reply(500);
-      Call.create(helper.createClient(), data, function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#update", function(){
-    it("should update a call", function(done){
-      var data = {state: "rejected" };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.update(data, done);
-    });
-  });
-  describe("#updateStatic", function(){
-    it("should update a call statically", function(done){
-      var data = {state: "rejected" };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
-      var client = helper.createClient();
-      Call.update(client, "1", data, done);
-    });
-  });
+describe("Call", function () {
 
-  describe("#playAudio", function(){
-    it("should play audio", function(done){
-      var data = {fileUrl: "url"};
-      helper.nock().post("/v1/users/FakeUserId/calls/1/audio", data).reply(200);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.playAudio(data, done);
-    });
-  });
+	before(function () {
+		nock.disableNetConnect();
+		helper.setupGlobalOptions();
+	});
 
-  describe("#speakSentence", function(){
-    it("should speak a sentense", function(done){
-      var data = {
-        gender: "female",
-        locale: "en_US",
-        voice: "kate",
-        sentence: "test",
-        tag: "tag"
-      };
-      helper.nock().post("/v1/users/FakeUserId/calls/1/audio", data).reply(200);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.speakSentence("test", "tag", done);
-    });
-    it("should speak a sentense (without tag)", function(done){
-      var data = {
-        gender: "female",
-        locale: "en_US",
-        voice: "kate",
-        sentence: "test",
-        tag: null
-      };
-      helper.nock().post("/v1/users/FakeUserId/calls/1/audio", data).reply(200);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.speakSentence("test", done);
-    });
-    it("should speak a sentense with different voice", function(done){
-      var data = {
-        gender: "male",
-        locale: "en_US",
-        voice: "tom",
-        sentence: "test",
-        tag: "tag"
-      };
-      helper.nock().post("/v1/users/FakeUserId/calls/1/audio", data).reply(200);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.speakSentence("test", "tag", "male", "tom", done);
-    });
-    it("should throw error if gender is passed without voice", function(done){
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.speakSentence("test", "tag", "male", function(err){
-        err.should.be.ok;
-        done();
-      });
-    });
-  });
-  describe("#playRecording", function(){
-    it("should play a recording", function(done){
-      var data = {
-        fileUrl: "url"
-      };
-      helper.nock().post("/v1/users/FakeUserId/calls/1/audio", data).reply(200);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.playRecording("url", done);
-    });
-  });
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
 
-  describe("#setDtmf", function(){
-    it("should set dtmf", function(done){
-      var data = {dtmfOut: "test" };
-      helper.nock().post("/v1/users/FakeUserId/calls/1/dtmf", data).reply(200);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.setDtmf("test", done);
-    });
-  });
-  describe("#createGather", function(){
-    var item = {
-        id: "101",
-        tag: "tag",
-        maxDigits: 1
-    };
-    var data = {
-        tag: "tag",
-        maxDigits: 1
-    };
-    it("should create a gather", function(done){
-      helper.nock().post("/v1/users/FakeUserId/calls/1/gather", data).reply(201, "", {"Location": "/v1/users/FakeUserId/calls/1/gather/101"});
-      helper.nock().get("/v1/users/FakeUserId/calls/1/gather/101").reply(200, item);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.createGather(data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should create a gather by sentence", function(done){
-      var d = {
-        tag: "1",
-        maxDigits: 1,
-        prompt: {
-          locale: "en_US",
-          gender: "female",
-          sentence: "test",
-          voice: "kate",
-          bargeable: true
-        }
-      };
-      helper.nock().post("/v1/users/FakeUserId/calls/1/gather", d).reply(201, "", {"Location": "/v1/users/FakeUserId/calls/1/gather/101"});
-      helper.nock().get("/v1/users/FakeUserId/calls/1/gather/101").reply(200, item);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.createGather("test",  function(err, i){
-        if(err){
-          return done(err);
-        }
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().post("/v1/users/FakeUserId/calls/1/gather").reply(500);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.createGather(data, function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#updateGather", function(){
-    var data = {
-        state: "completed"
-    };
-    it("should update a gather", function(done){
-      helper.nock().post("/v1/users/FakeUserId/calls/1/gather/101", data).reply(201, "", {"Location": "/v1/users/FakeUserId/calls/1/gather/101"});
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.updateGather("101", data, done);
-    });
-  });
-  describe("#getGather", function(){
-    var item = {
-        id: "101",
-        tag: "tag",
-        maxDigits: 1
-    };
-    it("should return a gather", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls/1/gather/101").reply(200, item);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.getGather("101", function(err, i){
-        if(err){
-          return done(err);
-        }
-        i.should.eql(item);
-        done();
-      });
-    });
-  });
-  describe("#getEvent", function(){
-    var item = {
-        id: "101"
-    };
-    it("should return an event", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls/1/events/101").reply(200, item);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.getEvent("101", function(err, i){
-        if(err){
-          return done(err);
-        }
-        i.should.eql(item);
-        done();
-      });
-    });
-  });
-  describe("#getEvents", function(){
-    var items = [{
-        id: "101"
-    }, {
-      id: "102"
-    }];
-    it("should return events", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls/1/events").reply(200, items);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.getEvents(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-  });
-  describe("#getRecordings", function(){
-    var items = [{
-        id: "101"
-    }, {
-      id: "102"
-    }];
-    it("should return recordings", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls/1/recordings").reply(200, items);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.getRecordings(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-  });
-  describe("#hangUp", function(){
-    it("should make hang up", function(done){
-      var data = {state: "completed" };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, data);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.hangUp(done);
-    });
-    it("should fail if remote request failed", function(done){
-      var data = {state: "completed" };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(400);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.hangUp(function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-    it("should fail if refreshing of call failed", function(done){
-      var data = {state: "completed" };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(500);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.hangUp(function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#answerOnIncoming", function(){
-    it("should answer to incoming call", function(done){
-      var data = {state: "active" };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, data);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.answerOnIncoming(done);
-    });
-    it("should fail if remote request failed", function(done){
-      var data = {state: "active" };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(400);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.answerOnIncoming(function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-    it("should fail if refreshing of call failed", function(done){
-      var data = {state: "active" };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(500);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.answerOnIncoming(function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#rejectIncoming", function(){
-    it("should reject a call", function(done){
-      var data = {state: "rejected" };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, data);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.rejectIncoming(done);
-    });
-    it("should fail if remote request failed", function(done){
-      var data = {state: "rejected" };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(400);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.rejectIncoming(function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-    it("should fail if refreshing of call failed", function(done){
-      var data = {state: "rejected" };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(500);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.rejectIncoming(function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#recordingOn", function(){
-    it("should tune on recording of a call", function(done){
-      var data = { recordingEnabled: true };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, data);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.recordingOn(done);
-    });
-    it("should fail if remote request failed", function(done){
-      var data = { recordingEnabled: true };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(400);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.recordingOn(function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-    it("should fail if refreshing of call failed", function(done){
-      var data = { recordingEnabled: true };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(500);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.recordingOn(function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#recordingOff", function(){
-    it("should tune on recording of a call", function(done){
-      var data = { recordingEnabled: false };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, data);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.recordingOff(done);
-    });
-    it("should fail if remote request failed", function(done){
-      var data = { recordingEnabled: false };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(400);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.recordingOff(function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-    it("should fail if refreshing of call failed", function(done){
-      var data = { recordingEnabled: false };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(500);
-      var call = new Call();
-      call.id = 1;
-      call.client = helper.createClient();
-      call.recordingOff(function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
+	describe("#list", function () {
+		var items = [ {
+			id    : "1",
+			from  : "111",
+			to    : "222",
+			state : "active"
+		}, {
+			id    : "2",
+			from  : "211",
+			to    : "322",
+			state : "active"
+		} ];
+
+		it("should return list of calls", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/calls?page=1").reply(200, items);
+			Call.list(helper.createClient(), { page : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return list of calls (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/calls?page=1").reply(200, items);
+			Call.list({ page : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return list of calls (without query)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/calls").reply(200, items);
+			Call.list(helper.createClient(), function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return list of calls (with default client, without query)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/calls").reply(200, items);
+			Call.list(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/calls").reply(500);
+			Call.list(helper.createClient(), {}, function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#get", function () {
+		var item = {
+			id    : "1",
+			from  : "111",
+			to    : "222",
+			state : "active"
+		};
+		it("should return a call", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, item);
+			Call.get(helper.createClient(), "1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should return a call (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, item);
+			Call.get("1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(500);
+			Call.get(helper.createClient(), "1", function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+
+	});
+
+	describe("#create", function () {
+		var item = {
+			id    : "1",
+			from  : "111",
+			to    : "222",
+			state : "active"
+		};
+
+		var data = {
+			from : "111",
+			to   : "222"
+		};
+
+		it("should create a call", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/calls", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/calls/1" });
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, item);
+			Call.create(helper.createClient(), data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should create a  call (with default client)", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/calls", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/calls/1" });
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, item);
+			Call.create(data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/calls").reply(500);
+			Call.create(helper.createClient(), data, function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#update", function () {
+		it("should update a call", function (done) {
+			var data = { state : "rejected" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.update(data, done);
+		});
+	});
+
+	describe("#updateStatic", function () {
+		it("should update a call statically", function (done) {
+			var data = { state : "rejected" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+			var client = helper.createClient();
+			Call.update(client, "1", data, done);
+		});
+	});
+
+	describe("#playAudio", function () {
+		it("should play audio", function (done) {
+			var data = { fileUrl : "url" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1/audio", data).reply(200);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.playAudio(data, done);
+		});
+	});
+
+	describe("#speakSentence", function () {
+		it("should speak a sentense", function (done) {
+			var data = {
+				gender   : "female",
+				locale   : "en_US",
+				voice    : "kate",
+				sentence : "test",
+				tag      : "tag"
+			};
+
+			helper.nock().post("/v1/users/FakeUserId/calls/1/audio", data).reply(200);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.speakSentence("test", "tag", done);
+		});
+
+		it("should speak a sentense (without tag)", function (done) {
+			var data = {
+				gender   : "female",
+				locale   : "en_US",
+				voice    : "kate",
+				sentence : "test",
+				tag      : null
+			};
+
+			helper.nock().post("/v1/users/FakeUserId/calls/1/audio", data).reply(200);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.speakSentence("test", done);
+		});
+
+		it("should speak a sentense with different voice", function (done) {
+			var data = {
+				gender   : "male",
+				locale   : "en_US",
+				voice    : "tom",
+				sentence : "test",
+				tag      : "tag"
+			};
+
+			helper.nock().post("/v1/users/FakeUserId/calls/1/audio", data).reply(200);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.speakSentence("test", "tag", "male", "tom", done);
+		});
+
+		it("should throw error if gender is passed without voice", function (done) {
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.speakSentence("test", "tag", "male", function (err) {
+				err.should.be.ok;
+				done();
+			});
+		});
+	});
+
+	describe("#playRecording", function () {
+		it("should play a recording", function (done) {
+			var data = {
+				fileUrl : "url"
+			};
+			helper.nock().post("/v1/users/FakeUserId/calls/1/audio", data).reply(200);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.playRecording("url", done);
+		});
+	});
+
+	describe("#setDtmf", function () {
+		it("should set dtmf", function (done) {
+			var data = { dtmfOut : "test" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1/dtmf", data).reply(200);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.setDtmf("test", done);
+		});
+	});
+
+	describe("#createGather", function () {
+		var item = {
+			id        : "101",
+			tag       : "tag",
+			maxDigits : 1
+		};
+		var data = {
+			tag       : "tag",
+			maxDigits : 1
+		};
+
+		it("should create a gather", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/calls/1/gather", data)
+				.reply(201, "", {
+					"Location" : "/v1/users/FakeUserId/calls/1/gather/101"
+				});
+			helper.nock().get("/v1/users/FakeUserId/calls/1/gather/101").reply(200, item);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.createGather(data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should create a gather by sentence", function (done) {
+			var d = {
+				tag       : "1",
+				maxDigits : 1,
+				prompt    : {
+					locale    : "en_US",
+					gender    : "female",
+					sentence  : "test",
+					voice     : "kate",
+					bargeable : true
+				}
+			};
+			helper.nock().post("/v1/users/FakeUserId/calls/1/gather", d).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/calls/1/gather/101" });
+			helper.nock().get("/v1/users/FakeUserId/calls/1/gather/101").reply(200, item);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.createGather("test",  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/calls/1/gather").reply(500);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.createGather(data, function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#updateGather", function () {
+		var data = {
+			state : "completed"
+		};
+		it("should update a gather", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/calls/1/gather/101", data)
+				.reply(201, "", {
+					"Location" : "/v1/users/FakeUserId/calls/1/gather/101"
+				});
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.updateGather("101", data, done);
+		});
+	});
+
+	describe("#getGather", function () {
+		var item = {
+			id        : "101",
+			tag       : "tag",
+			maxDigits : 1
+		};
+		it("should return a gather", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/calls/1/gather/101").reply(200, item);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.getGather("101", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				i.should.eql(item);
+				done();
+			});
+		});
+	});
+
+	describe("#getEvent", function () {
+		var item = {
+			id : "101"
+		};
+		it("should return an event", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/calls/1/events/101").reply(200, item);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.getEvent("101", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				i.should.eql(item);
+				done();
+			});
+		});
+	});
+
+	describe("#getEvents", function () {
+		var items = [ {
+			id : "101"
+		}, {
+			id : "102"
+		} ];
+		it("should return events", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/calls/1/events").reply(200, items);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.getEvents(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+	});
+
+	describe("#getRecordings", function () {
+		var items = [ {
+			id : "101"
+		}, {
+			id : "102"
+		} ];
+		it("should return recordings", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/calls/1/recordings").reply(200, items);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.getRecordings(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+	});
+
+	describe("#hangUp", function () {
+		it("should make hang up", function (done) {
+			var data = { state : "completed" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, data);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.hangUp(done);
+		});
+
+		it("should fail if remote request failed", function (done) {
+			var data = { state : "completed" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(400);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.hangUp(function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+
+		it("should fail if refreshing of call failed", function (done) {
+			var data = { state : "completed" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(500);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.hangUp(function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#answerOnIncoming", function () {
+		it("should answer to incoming call", function (done) {
+			var data = { state : "active" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, data);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.answerOnIncoming(done);
+		});
+
+		it("should fail if remote request failed", function (done) {
+			var data = { state : "active" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(400);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.answerOnIncoming(function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+
+		it("should fail if refreshing of call failed", function (done) {
+			var data = { state : "active" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(500);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.answerOnIncoming(function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#rejectIncoming", function () {
+		it("should reject a call", function (done) {
+			var data = { state : "rejected" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, data);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.rejectIncoming(done);
+		});
+
+		it("should fail if remote request failed", function (done) {
+			var data = { state : "rejected" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(400);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.rejectIncoming(function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+
+		it("should fail if refreshing of call failed", function (done) {
+			var data = { state : "rejected" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(500);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.rejectIncoming(function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#recordingOn", function () {
+		it("should tune on recording of a call", function (done) {
+			var data = { recordingEnabled : true };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, data);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.recordingOn(done);
+		});
+
+		it("should fail if remote request failed", function (done) {
+			var data = { recordingEnabled : true };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(400);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.recordingOn(function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+
+		it("should fail if refreshing of call failed", function (done) {
+			var data = { recordingEnabled : true };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(500);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.recordingOn(function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#recordingOff", function () {
+		it("should tune on recording of a call", function (done) {
+			var data = { recordingEnabled : false };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, data);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.recordingOff(done);
+		});
+
+		it("should fail if remote request failed", function (done) {
+			var data = { recordingEnabled : false };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(400);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.recordingOff(function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+
+		it("should fail if refreshing of call failed", function (done) {
+			var data = { recordingEnabled : false };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(500);
+			var call = new Call();
+			call.id = 1;
+			call.client = helper.createClient();
+			call.recordingOff(function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
 });

--- a/test/client.js
+++ b/test/client.js
@@ -2,167 +2,167 @@ var Client = require("../").Client;
 var errors = require("../").errors;
 var nock = require("nock");
 var helper = require("./helper");
-describe("client tests", function(){
-  before(function(){
-    nock.disableNetConnect();
-  });
-  after(function(){
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-  describe("#constructor", function(){
-    it("should create client instance", function(){
-      var client = new Client("1", "2", "3");
-      client.should.be.instanceof(Client);
-      Client("1", "2", "3").should.be.instanceof(Client);
-    });
-    it("should fail if auth data are missing", function(){
-      var options = Client.globalOptions;
-      try{
-        Client.globalOptions = {};
-        new Client();
-        throw new Error("An error is estimated");
-      }
-      catch(err){
-        err.should.be.instanceof(errors.MissingCredentialsError);
-      }
-      finally{
-        Client.globalOptions = options;
-      }
-    });
-  });
-  describe("#makeRequest", function(){
-    var client = new Client("accountId", "user", "password");
-    it("should make GET request", function(done){
-      var span = helper.nock().get("/v1/test")
-        .reply(200, {test: "test"});
-      client.makeRequest("get", "/test", function(err, r){
-        if(err){
-          return done(err);
-        }
-        r.test.should.equal("test");
-        done();
-      });
-    });
+describe("client tests", function () {
+	before(function () {
+		nock.disableNetConnect();
+	});
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+	describe("#constructor", function () {
+		it("should create client instance", function () {
+			var client = new Client("1", "2", "3");
+			client.should.be.instanceof(Client);
+			Client("1", "2", "3").should.be.instanceof(Client);
+		});
+		it("should fail if auth data are missing", function () {
+			var options = Client.globalOptions;
+			try {
+				Client.globalOptions = {};
+				new Client();
+				throw new Error("An error is estimated");
+			}
+			catch (err){
+				err.should.be.instanceof(errors.MissingCredentialsError);
+			}
+			finally{
+				Client.globalOptions = options;
+			}
+		});
+	});
+	describe("#makeRequest", function () {
+		var client = new Client("accountId", "user", "password");
+		it("should make GET request", function (done) {
+			var span = helper.nock().get("/v1/test")
+			.reply(200, { test : "test" });
+			client.makeRequest("get", "/test", function (err, r) {
+				if (err){
+					return done(err);
+				}
+				r.test.should.equal("test");
+				done();
+			});
+		});
 
-    it("should make GET request with query", function(done){
-      var c = new Client({
-        userId: "userId",
-        apiToken: "token",
-        apiSecret: "secret"
-      });
-      helper.nock().get("/v1/test?data=true")
-        .reply(200, {test: "test"});
-      c.makeRequest("get", "/test", {data: true}, function(err, r){
-        if(err){
-          return done(err);
-        }
-        r.test.should.equal("test");
-        done();
-      });
-    });
-    it("should  handle requests without output", function(done){
-      helper.nock().get("/v1/test").reply(200);
-      client.makeRequest("get", "/test", done);
-    });
+		it("should make GET request with query", function (done) {
+			var c = new Client({
+				userId    : "userId",
+				apiToken  : "token",
+				apiSecret : "secret"
+			});
+			helper.nock().get("/v1/test?data=true")
+			.reply(200, { test : "test" });
+			c.makeRequest("get", "/test", { data : true }, function (err, r) {
+				if (err){
+					return done(err);
+				}
+				r.test.should.equal("test");
+				done();
+			});
+		});
+		it("should  handle requests without output", function (done) {
+			helper.nock().get("/v1/test").reply(200);
+			client.makeRequest("get", "/test", done);
+		});
 
-    it("should make request and handle error status", function(done){
-      helper.nock().get("/v1/test").reply(400, {message: "Error"});
-      client.makeRequest("get", "/test", function(err, r){
-        if(err){
-          err.message.should.equal("Error");
-          return done();
-        }
-        done(new Error("Error is expected"));
-      });
-    });
+		it("should make request and handle error status", function (done) {
+			helper.nock().get("/v1/test").reply(400, { message : "Error" });
+			client.makeRequest("get", "/test", function (err, r) {
+				if (err){
+					err.message.should.equal("Error");
+					return done();
+				}
+				done(new Error("Error is expected"));
+			});
+		});
 
-    it("should make request and handle error status (without response message)", function(done){
-      helper.nock().get("/v1/test").reply(400);
-      client.makeRequest("get", "/test", function(err, r){
-        if(err){
-          return done();
-        }
-        done(new Error("Error is expected"));
-      });
-    });
-    it("should make POST request", function(done){
-      var data = {
-        root: {
-          test1: ["test1", "test2"],
-          test2: "2014-11-20T00:00:00.000Z",
-        }
-      };
-      helper.nock().post("/v1/test", data).reply(200, {
-        test: "2014-11-19T13:44:38.123Z",
-        test1: 10,
-        test2: ["2014-11-19T13:44:38.123Z", {test: "2014-11-19T13:44:38.123Z"}]
-      });
-      client.makeRequest("post", "/test", data, function(err, r){
-        if(err){
-          return done(err);
-        }
-        r.test.should.be.instanceof(Date);
-        r.test.toISOString().should.equal("2014-11-19T13:44:38.123Z");
-        r.test2[0].toISOString().should.equal("2014-11-19T13:44:38.123Z");
-        r.test2[1].test.toISOString().should.equal("2014-11-19T13:44:38.123Z");
-        done();
-      });
-    });
-    it("should make PUT request", function(done){
-      var data = {data: 10};
-      helper.nock().put("/v1/test", data)
-        .reply(200, {test: "test"});
-      client.makeRequest("put", "/test", data, function(err, r){
-        if(err){
-          return done(err);
-        }
-        r.test.should.equal("test");
-        done();
-      });
-    });
-    it("should make DELETE request", function(done){
-      helper.nock().delete("/v1/test")
-        .reply(200, {test: "test"});
-      client.makeRequest("del", "/test", function(err, r){
-        if(err){
-          return done(err);
-        }
-        r.test.should.equal("test");
-        done();
-      });
-    });
-  });
-  describe("#concatUserPath", function(){
-    it("should return formatted url", function(){
-      var client = new Client({userId: "userId"});
-      client.concatUserPath("test").should.equal("/users/userId/test");
-      client.concatUserPath("/test1").should.equal("/users/userId/test1");
-    });
-  });
-  describe("#getIdFromLocationHeader", function(){
-    it("should return formatted url", function(done){
-      Client.getIdFromLocationHeader("/path1/path2/10", function(err, id){
-        if(err){
-          return done(err);
-        }
-        id.should.equal("10");
-        Client.getIdFromLocationHeader("/path1/100/path2/11", function(err, id){
-          if(err){
-            return done(err);
-          }
-          id.should.equal("11");
-          done();
-        });
-      });
-    });
-    it("should fail if id is missing", function(done){
-      Client.getIdFromLocationHeader("nothing", function(err, id){
-        if(err){
-          return done();
-        }
-        done(new Error("Error is estimated"));
-      });
-    });
-  });
+		it("should make request and handle error status (without response message)", function (done) {
+			helper.nock().get("/v1/test").reply(400);
+			client.makeRequest("get", "/test", function (err, r) {
+				if (err){
+					return done();
+				}
+				done(new Error("Error is expected"));
+			});
+		});
+		it("should make POST request", function (done) {
+			var data = {
+				root : {
+					test1 : [ "test1", "test2" ],
+					test2 : "2014-11-20T00:00:00.000Z",
+				}
+			};
+			helper.nock().post("/v1/test", data).reply(200, {
+				test  : "2014-11-19T13:44:38.123Z",
+				test1 : 10,
+				test2 : [ "2014-11-19T13:44:38.123Z", { test : "2014-11-19T13:44:38.123Z" } ]
+			});
+			client.makeRequest("post", "/test", data, function (err, r) {
+				if (err){
+					return done(err);
+				}
+				r.test.should.be.instanceof(Date);
+				r.test.toISOString().should.equal("2014-11-19T13:44:38.123Z");
+				r.test2[0].toISOString().should.equal("2014-11-19T13:44:38.123Z");
+				r.test2[1].test.toISOString().should.equal("2014-11-19T13:44:38.123Z");
+				done();
+			});
+		});
+		it("should make PUT request", function (done) {
+			var data = { data : 10 };
+			helper.nock().put("/v1/test", data)
+			.reply(200, { test : "test" });
+			client.makeRequest("put", "/test", data, function (err, r) {
+				if (err){
+					return done(err);
+				}
+				r.test.should.equal("test");
+				done();
+			});
+		});
+		it("should make DELETE request", function (done) {
+			helper.nock().delete("/v1/test")
+			.reply(200, { test : "test" });
+			client.makeRequest("del", "/test", function (err, r) {
+				if (err){
+					return done(err);
+				}
+				r.test.should.equal("test");
+				done();
+			});
+		});
+	});
+	describe("#concatUserPath", function () {
+		it("should return formatted url", function () {
+			var client = new Client({ userId : "userId" });
+			client.concatUserPath("test").should.equal("/users/userId/test");
+			client.concatUserPath("/test1").should.equal("/users/userId/test1");
+		});
+	});
+	describe("#getIdFromLocationHeader", function () {
+		it("should return formatted url", function (done) {
+			Client.getIdFromLocationHeader("/path1/path2/10", function (err, id) {
+				if (err){
+					return done(err);
+				}
+				id.should.equal("10");
+				Client.getIdFromLocationHeader("/path1/100/path2/11", function (err, id) {
+					if (err){
+						return done(err);
+					}
+					id.should.equal("11");
+					done();
+				});
+			});
+		});
+		it("should fail if id is missing", function (done) {
+			Client.getIdFromLocationHeader("nothing", function (err, id) {
+				if (err){
+					return done();
+				}
+				done(new Error("Error is estimated"));
+			});
+		});
+	});
 });

--- a/test/client.js
+++ b/test/client.js
@@ -23,10 +23,10 @@ describe("client tests", function () {
 				new Client();
 				throw new Error("An error is estimated");
 			}
-			catch (err){
+			catch (err) {
 				err.should.be.instanceof(errors.MissingCredentialsError);
 			}
-			finally{
+			finally {
 				Client.globalOptions = options;
 			}
 		});
@@ -37,7 +37,7 @@ describe("client tests", function () {
 			var span = helper.nock().get("/v1/test")
 			.reply(200, { test : "test" });
 			client.makeRequest("get", "/test", function (err, r) {
-				if (err){
+				if (err) {
 					return done(err);
 				}
 				r.test.should.equal("test");
@@ -54,7 +54,7 @@ describe("client tests", function () {
 			helper.nock().get("/v1/test?data=true")
 			.reply(200, { test : "test" });
 			c.makeRequest("get", "/test", { data : true }, function (err, r) {
-				if (err){
+				if (err) {
 					return done(err);
 				}
 				r.test.should.equal("test");
@@ -69,7 +69,7 @@ describe("client tests", function () {
 		it("should make request and handle error status", function (done) {
 			helper.nock().get("/v1/test").reply(400, { message : "Error" });
 			client.makeRequest("get", "/test", function (err, r) {
-				if (err){
+				if (err) {
 					err.message.should.equal("Error");
 					return done();
 				}
@@ -80,7 +80,7 @@ describe("client tests", function () {
 		it("should make request and handle error status (without response message)", function (done) {
 			helper.nock().get("/v1/test").reply(400);
 			client.makeRequest("get", "/test", function (err, r) {
-				if (err){
+				if (err) {
 					return done();
 				}
 				done(new Error("Error is expected"));
@@ -99,7 +99,7 @@ describe("client tests", function () {
 				test2 : [ "2014-11-19T13:44:38.123Z", { test : "2014-11-19T13:44:38.123Z" } ]
 			});
 			client.makeRequest("post", "/test", data, function (err, r) {
-				if (err){
+				if (err) {
 					return done(err);
 				}
 				r.test.should.be.instanceof(Date);
@@ -114,7 +114,7 @@ describe("client tests", function () {
 			helper.nock().put("/v1/test", data)
 			.reply(200, { test : "test" });
 			client.makeRequest("put", "/test", data, function (err, r) {
-				if (err){
+				if (err) {
 					return done(err);
 				}
 				r.test.should.equal("test");
@@ -125,7 +125,7 @@ describe("client tests", function () {
 			helper.nock().delete("/v1/test")
 			.reply(200, { test : "test" });
 			client.makeRequest("del", "/test", function (err, r) {
-				if (err){
+				if (err) {
 					return done(err);
 				}
 				r.test.should.equal("test");
@@ -143,12 +143,12 @@ describe("client tests", function () {
 	describe("#getIdFromLocationHeader", function () {
 		it("should return formatted url", function (done) {
 			Client.getIdFromLocationHeader("/path1/path2/10", function (err, id) {
-				if (err){
+				if (err) {
 					return done(err);
 				}
 				id.should.equal("10");
 				Client.getIdFromLocationHeader("/path1/100/path2/11", function (err, id) {
-					if (err){
+					if (err) {
 						return done(err);
 					}
 					id.should.equal("11");
@@ -158,7 +158,7 @@ describe("client tests", function () {
 		});
 		it("should fail if id is missing", function (done) {
 			Client.getIdFromLocationHeader("nothing", function (err, id) {
-				if (err){
+				if (err) {
 					return done();
 				}
 				done(new Error("Error is estimated"));

--- a/test/compatibility.js
+++ b/test/compatibility.js
@@ -3,411 +3,476 @@ var Client = lib.Client;
 var nock = require("nock");
 var helper = require("./helper");
 
-describe("Client compatibility functions", function(){
-  var client;
-  before(function(){
-    client = new Client("api.catapult.inetwork.com", "FakeUserId", "FakeApiToken", "FakeApiSecret");
-    nock.disableNetConnect();
-  });
-  after(function(){
-    nock.enableNetConnect();
-  });
-  afterEach(function(){
-    nock.cleanAll();
-  });
-  describe("#sendCall", function(){
-    var item = {
-        id: "1",
-        from: "111",
-        to: "222",
-        state: "active"
-    };
-    var data = {
-        from: "111",
-        to: "222",
-    };
-    it("should create a call", function(done){
-      helper.nock().post("/v1/users/FakeUserId/calls", data).reply(201, "", {"Location": "/v1/users/FakeUserId/calls/1"});
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, item);
-      client.sendCall(data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-  });
-  describe("#changeCall", function(){
-    it("should update a call", function(done){
-      var data = {state: "rejected" };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
-      client.changeCall("1", data, done);
-    });
-  });
-  describe("#startRecording", function(){
-    it("should tune on recording of a call", function(done){
-      var data = { recordingEnabled: true };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, data);
-      client.startRecording("1", done);
-    });
-  });
-  describe("#stopRecording", function(){
-    it("should tune off recording of a call", function(done){
-      var data = { recordingEnabled: false };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, data);
-      client.stopRecording("1", done);
-    });
-  });
-  describe("#getRecording", function(){
-    var item = {
-        id: "1",
-        call: "call1",
-        media: "media1"
-    };
-    it("should return a recording", function(done){
-      helper.nock().get("/v1/users/FakeUserId/recordings/1").reply(200, item);
-      client.getRecording("1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-  });
-  describe("#getRecordings", function(){
-    var items = [{
-        id: "101"
-    }, {
-      id: "102"
-    }];
-    it("should return recordings", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls/1/recordings").reply(200, items);
-      client.getRecordings("1", function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-  });
-  describe("#transferCall", function(){
-    it("should update a call", function(done){
-      var data = {call: {id: "1"}, data: "test" };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", {data: "test"}).reply(200);
-      client.transferCall(data, done);
-    });
-  });
-  describe("#hangUp", function(){
-    it("should update a call", function(done){
-      var data = {state: "completed" };
-      helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
-      client.hangUp("1", done);
-    });
-  });
-  describe("#getCall", function(){
-    var item = {
-        id: "1",
-        from: "111",
-        to: "222",
-        state: "active"
-    };
-    it("should return a call", function(done){
-      helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, item);
-      client.getCall("1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-  });
-  describe("#playCallAudio", function(){
-    it("should play audio", function(done){
-      var data = {fileUrl: "url"};
-      helper.nock().post("/v1/users/FakeUserId/calls/1/audio", data).reply(200);
-      client.playCallAudio({callId: "1", fileUrl: "url"}, done);
-    });
-  });
-  describe("#sendMessage", function(){
-    var item = {
-      id: "1",
-      from: "from",
-      to: "to",
-      text: "text"
-    };
-    var data = {
-      from: "from",
-      to: "to",
-      text: "text"
-    };
-    it("should create a message", function(done){
-      helper.nock().post("/v1/users/FakeUserId/messages", data).reply(201, "", {"Location": "/v1/users/FakeUserId/messages/1"});
-      helper.nock().get("/v1/users/FakeUserId/messages/1").reply(200, item);
-      client.sendMessage(data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-  });
-  describe("#getMessage", function(){
-    var item = {
-      id: "1",
-      from: "from1",
-      to: "to1",
-      text: "message"
-    };
-    it("should return a message", function(done){
-      helper.nock().get("/v1/users/FakeUserId/messages/1").reply(200, item);
-      client.getMessage("1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-  });
-  describe("#getMessages", function(){
-    var items = [{
-        id: "1",
-        from: "from1",
-        to: "to1",
-        text: "text1"
-      },{
-        id: "2",
-        from: "from2",
-        to: "to2",
-        text: "text2"
-      }
-    ];
-    it("should return list of messages", function(done){
-      helper.nock().get("/v1/users/FakeUserId/messages").reply(200, items);
-      client.getMessages(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-  });
-  describe("#getAvailableNumbers", function(){
-    var items = [{
-      number: "1",
-      city: "City1",
-      lata: "Lata1",
-      nationalNumber: "NationalNumber1",
-      patternMatch: "PatternMatch1",
-      price: 0.01,
-      rateCenter: "RateCenter1",
-      state: "State1"
-    }, {
-      number: "2",
-      city: "City2",
-      lata: "Lata2",
-      nationalNumber: "NationalNumber2",
-      patternMatch: "PatternMatch2",
-      price: 0.02,
-      rateCenter: "RateCenter2",
-      state: "State2"
-    }];
-    it("should return tollFree numbers", function(done){
-      helper.nock().get("/v1/availableNumbers/tollFree?criteria1=1").reply(200, items);
-      client.getAvailableNumbers({criteria1: 1, numberType: "tollFree"},function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return local numbers", function(done){
-      helper.nock().get("/v1/availableNumbers/local?criteria1=1").reply(200, items);
-      client.getAvailableNumbers({criteria1: 1, numberType: "local"},function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-  });
-  describe("#acquirePhoneNumber", function(){
-    var item = {
-        id: "1",
-        number: "111111",
-        numberState: "enabled"
-    };
-    var data = {
-        number: "111111"
-    };
-    it("should create a phoneNumber", function(done){
-      helper.nock().post("/v1/users/FakeUserId/phoneNumbers", data).reply(201, "", {"Location": "/v1/users/FakeUserId/phoneNumbers/1"});
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(200, item);
-      client.acquirePhoneNumber(data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-  });
-  describe("#getPhoneNumber", function(){
-    var item = {
-        id: "1",
-        number: "111111",
-        numberState: "enabled"
-    };
-    it("should return a phoneNumber", function(done){
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(200, item);
-      client.getPhoneNumber("1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-  });
-  describe("#getPhoneNumbers", function(){
-    var items = [{
-        id: "1",
-        number: "111111",
-        numberState: "enabled",
-      },{
-        id: "2",
-        number: "222222",
-        numberState: "enabled",
-      }
-    ];
-    it("should return list of phoneNumbers", function(done){
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers").reply(200, items);
-      client.getPhoneNumbers(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-  });
-  describe("#updatePhoneNumber", function(){
-    it("should update a phoneNumber", function(done){
-      var data = {numberState: "disabled" };
-      helper.nock().post("/v1/users/FakeUserId/phoneNumbers/1", data).reply(200);
-      client.updatePhoneNumber("1", data, done);
-    });
-  });
-  describe("#deletePhoneNumber", function(){
-    it("should delete a phoneNumber", function(done){
-      helper.nock().delete("/v1/users/FakeUserId/phoneNumbers/1").reply(200);
-      client.deletePhoneNumber("1", done);
-    });
-  });
-  describe("#getApplications", function(){
-    var items = [{
-        id: "1",
-        name: "app1",
-        incomingCallUrl: "http://host1"
-      },{
-        id: "2",
-        name: "app2",
-        incomingCallUrl: "http://host2"
-      }
-    ];
-    it("should return list of applications", function(done){
-      helper.nock().get("/v1/users/FakeUserId/applications").reply(200, items);
-      client.getApplications(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-  });
-  describe("#portIn", function(){
-    it("should throw an error", function(done){
-      client.portIn({}, function(err){
-        if(err){
-          return done();
-        }
-        done("An error is estimated");
-      });
-    });
-  });
-  describe("#cancelPortIn", function(){
-    it("should throw an error", function(done){
-      client.cancelPortIn("id", function(err){
-        if(err){
-          return done();
-        }
-        done("An error is estimated");
-      });
-    });
-  });
-  describe("#uploadLOA", function(){
-    it("should throw an error", function(done){
-      client.uploadLOA("id", "file", function(err){
-        if(err){
-          return done();
-        }
-        done("An error is estimated");
-      });
-    });
-  });
-  describe("#getPortInState", function(){
-    it("should throw an error", function(done){
-      client.getPortInState("id", function(err){
-        if(err){
-          return done();
-        }
-        done("An error is estimated");
-      });
-    });
-  });
-  describe("#checkPortInAvailability", function(){
-    it("should throw an error", function(done){
-      client.checkPortInAvailability({}, function(err){
-        if(err){
-          return done();
-        }
-        done("An error is estimated");
-      });
-    });
-  });
-  describe("obsolete types", function(){
-    it("should allow to create instances of obsolete types", function(){
-      new lib.Application("test");
-      new lib.Audio("test");
-      new lib.AvailableNumber("test");
-      new lib.AvailableNumberSearchCriteria("test");
-      new lib.Call("test");
-      new lib.CallTransfer("test");
-      new lib.LNPAvailabilityCheck("test");
-      new lib.Message("test");
-      new lib.PhoneNumber("test");
-      new lib.PortInData("test");
-    });
-  });
+describe("Client compatibility functions", function () {
+	var client;
+	before(function () {
+		client = new Client("api.catapult.inetwork.com", "FakeUserId", "FakeApiToken", "FakeApiSecret");
+		nock.disableNetConnect();
+	});
+
+	after(function () {
+		nock.enableNetConnect();
+	});
+
+	afterEach(function () {
+		nock.cleanAll();
+	});
+
+	describe("#sendCall", function () {
+		var item = {
+			id    : "1",
+			from  : "111",
+			to    : "222",
+			state : "active"
+		};
+
+		var data = {
+			from : "111",
+			to   : "222"
+		};
+
+		it("should create a call", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/calls", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/calls/1" });
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, item);
+			client.sendCall(data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+	});
+
+	describe("#changeCall", function () {
+		it("should update a call", function (done) {
+			var data = { state : "rejected" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+			client.changeCall("1", data, done);
+		});
+	});
+
+	describe("#startRecording", function () {
+		it("should tune on recording of a call", function (done) {
+			var data = { recordingEnabled : true };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, data);
+			client.startRecording("1", done);
+		});
+	});
+
+	describe("#stopRecording", function () {
+		it("should tune off recording of a call", function (done) {
+			var data = { recordingEnabled : false };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, data);
+			client.stopRecording("1", done);
+		});
+	});
+
+	describe("#getRecording", function () {
+		var item = {
+			id    : "1",
+			call  : "call1",
+			media : "media1"
+		};
+		it("should return a recording", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/recordings/1").reply(200, item);
+			client.getRecording("1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+	});
+
+	describe("#getRecordings", function () {
+		var items = [ {
+			id : "101"
+		}, {
+			id : "102"
+		} ];
+		it("should return recordings", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/calls/1/recordings").reply(200, items);
+			client.getRecordings("1", function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+	});
+
+	describe("#transferCall", function () {
+		it("should update a call", function (done) {
+			var data = { call : { id : "1" }, data : "test" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", { data : "test" }).reply(200);
+			client.transferCall(data, done);
+		});
+	});
+
+	describe("#hangUp", function () {
+		it("should update a call", function (done) {
+			var data = { state : "completed" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1", data).reply(200);
+			client.hangUp("1", done);
+		});
+	});
+
+	describe("#getCall", function () {
+		var item = {
+			id    : "1",
+			from  : "111",
+			to    : "222",
+			state : "active"
+		};
+		it("should return a call", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/calls/1").reply(200, item);
+			client.getCall("1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+	});
+
+	describe("#playCallAudio", function () {
+		it("should play audio", function (done) {
+			var data = { fileUrl : "url" };
+			helper.nock().post("/v1/users/FakeUserId/calls/1/audio", data).reply(200);
+			client.playCallAudio({ callId : "1", fileUrl : "url" }, done);
+		});
+	});
+
+	describe("#sendMessage", function () {
+		var item = {
+			id   : "1",
+			from : "from",
+			to   : "to",
+			text : "text"
+		};
+
+		var data = {
+			from : "from",
+			to   : "to",
+			text : "text"
+		};
+
+		it("should create a message", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/messages", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/messages/1" });
+			helper.nock().get("/v1/users/FakeUserId/messages/1").reply(200, item);
+			client.sendMessage(data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+	});
+
+	describe("#getMessage", function () {
+		var item = {
+			id   : "1",
+			from : "from1",
+			to   : "to1",
+			text : "message"
+		};
+		it("should return a message", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/messages/1").reply(200, item);
+			client.getMessage("1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+	});
+
+	describe("#getMessages", function () {
+		var items = [ {
+			id   : "1",
+			from : "from1",
+			to   : "to1",
+			text : "text1"
+		}, {
+			id   : "2",
+			from : "from2",
+			to   : "to2",
+			text : "text2"
+		} ];
+
+		it("should return list of messages", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/messages").reply(200, items);
+			client.getMessages(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+	});
+
+	describe("#getAvailableNumbers", function () {
+		var items = [ {
+			number         : "1",
+			city           : "City1",
+			lata           : "Lata1",
+			nationalNumber : "NationalNumber1",
+			patternMatch   : "PatternMatch1",
+			price          : 0.01,
+			rateCenter     : "RateCenter1",
+			state          : "State1"
+		}, {
+			number         : "2",
+			city           : "City2",
+			lata           : "Lata2",
+			nationalNumber : "NationalNumber2",
+			patternMatch   : "PatternMatch2",
+			price          : 0.02,
+			rateCenter     : "RateCenter2",
+			state          : "State2"
+		} ];
+
+		it("should return tollFree numbers", function (done) {
+			helper.nock().get("/v1/availableNumbers/tollFree?criteria1=1").reply(200, items);
+			client.getAvailableNumbers({ criteria1 : 1, numberType : "tollFree" }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return local numbers", function (done) {
+			helper.nock().get("/v1/availableNumbers/local?criteria1=1").reply(200, items);
+			client.getAvailableNumbers({ criteria1 : 1, numberType : "local" }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+	});
+
+	describe("#acquirePhoneNumber", function () {
+		var item = {
+			id          : "1",
+			number      : "111111",
+			numberState : "enabled"
+		};
+		var data = {
+			number : "111111"
+		};
+		it("should create a phoneNumber", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/phoneNumbers", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/phoneNumbers/1" });
+			helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(200, item);
+			client.acquirePhoneNumber(data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+	});
+
+	describe("#getPhoneNumber", function () {
+		var item = {
+			id          : "1",
+			number      : "111111",
+			numberState : "enabled"
+		};
+
+		it("should return a phoneNumber", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(200, item);
+			client.getPhoneNumber("1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+	});
+
+	describe("#getPhoneNumbers", function () {
+		var items = [ {
+			id          : "1",
+			number      : "111111",
+			numberState : "enabled"
+		}, {
+			id          : "2",
+			number      : "222222",
+			numberState : "enabled"
+		} ];
+
+		it("should return list of phoneNumbers", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/phoneNumbers").reply(200, items);
+			client.getPhoneNumbers(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+	});
+
+	describe("#updatePhoneNumber", function () {
+		it("should update a phoneNumber", function (done) {
+			var data = { numberState : "disabled" };
+			helper.nock().post("/v1/users/FakeUserId/phoneNumbers/1", data).reply(200);
+			client.updatePhoneNumber("1", data, done);
+		});
+	});
+
+	describe("#deletePhoneNumber", function () {
+		it("should delete a phoneNumber", function (done) {
+			helper.nock().delete("/v1/users/FakeUserId/phoneNumbers/1").reply(200);
+			client.deletePhoneNumber("1", done);
+		});
+	});
+
+	describe("#getApplications", function () {
+		var items = [ {
+			id              : "1",
+			name            : "app1",
+			incomingCallUrl : "http://host1"
+		}, {
+			id              : "2",
+			name            : "app2",
+			incomingCallUrl : "http://host2"
+		} ];
+
+		it("should return list of applications", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/applications").reply(200, items);
+			client.getApplications(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+	});
+
+	describe("#portIn", function () {
+		it("should throw an error", function (done) {
+			client.portIn({}, function (err) {
+				if (err) {
+					return done();
+				}
+
+				done("An error is estimated");
+			});
+		});
+	});
+
+	describe("#cancelPortIn", function () {
+		it("should throw an error", function (done) {
+			client.cancelPortIn("id", function (err) {
+				if (err) {
+					return done();
+				}
+
+				done("An error is estimated");
+			});
+		});
+	});
+
+	describe("#uploadLOA", function () {
+		it("should throw an error", function (done) {
+			client.uploadLOA("id", "file", function (err) {
+				if (err) {
+					return done();
+				}
+
+				done("An error is estimated");
+			});
+		});
+	});
+
+	describe("#getPortInState", function () {
+		it("should throw an error", function (done) {
+			client.getPortInState("id", function (err) {
+				if (err) {
+					return done();
+				}
+
+				done("An error is estimated");
+			});
+		});
+	});
+
+	describe("#checkPortInAvailability", function () {
+		it("should throw an error", function (done) {
+			client.checkPortInAvailability({}, function (err) {
+				if (err) {
+					return done();
+				}
+
+				done("An error is estimated");
+			});
+		});
+	});
+
+	describe("obsolete types", function () {
+		it("should allow to create instances of obsolete types", function () {
+			new lib.Application("test");
+			new lib.Audio("test");
+			new lib.AvailableNumber("test");
+			new lib.AvailableNumberSearchCriteria("test");
+			new lib.Call("test");
+			new lib.CallTransfer("test");
+			new lib.LNPAvailabilityCheck("test");
+			new lib.Message("test");
+			new lib.PhoneNumber("test");
+			new lib.PortInData("test");
+		});
+	});
 });

--- a/test/conference.js
+++ b/test/conference.js
@@ -3,235 +3,269 @@ var helper = require("./helper");
 var nock = require("nock");
 var Conference = lib.Conference;
 
-describe("Conference", function(){
-  before(function(){
-    nock.disableNetConnect();
-    helper.setupGlobalOptions();
-  });
-  after(function(){
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-  describe("#get", function(){
-    var item = {
-        id: "1",
-        from: "from1",
-        callbackUrl: "http://host1"
-    };
-    it("should return a conference", function(done){
-      helper.nock().get("/v1/users/FakeUserId/conferences/1").reply(200, item);
-      Conference.get(helper.createClient(), "1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should return a conference (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/conferences/1").reply(200, item);
-      Conference.get("1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().get("/v1/users/FakeUserId/conferences/1").reply(500);
-      Conference.get(helper.createClient(), "1", function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#create", function(){
-    var item = {
-        id: "1",
-        from: "from1",
-        callbackUrl: "http://host1"
-    };
-    var data = {
-        from: "from1",
-        callbackUrl: "http://host1"
-    };
-    it("should create a conference", function(done){
-      helper.nock().post("/v1/users/FakeUserId/conferences", data).reply(201, "", {"Location": "/v1/users/FakeUserId/conferences/1"});
-      helper.nock().get("/v1/users/FakeUserId/conferences/1").reply(200, item);
-      Conference.create(helper.createClient(), data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should create a conference (with default client)", function(done){
-      helper.nock().post("/v1/users/FakeUserId/conferences", data).reply(201, "", {"Location": "/v1/users/FakeUserId/conferences/1"});
-      helper.nock().get("/v1/users/FakeUserId/conferences/1").reply(200, item);
-      Conference.create(data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().post("/v1/users/FakeUserId/conferences").reply(500);
-      Conference.create(helper.createClient(), data, function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#update", function(){
-    it("should update a conference", function(done){
-      var data = {callbackUrl: "http://host2" };
-      helper.nock().post("/v1/users/FakeUserId/conferences/1", data).reply(200);
-      var conference = new Conference();
-      conference.id = 1;
-      conference.client = helper.createClient();
-      conference.update(data, done);
-    });
-  });
+describe("Conference", function () {
+	before(function () {
+		nock.disableNetConnect();
+		helper.setupGlobalOptions();
+	});
 
-  describe("#complete", function(){
-    it("should update a conference", function(done){
-      var data = {state: "completed" };
-      helper.nock().post("/v1/users/FakeUserId/conferences/1", data).reply(200);
-      var conference = new Conference();
-      conference.id = 1;
-      conference.client = helper.createClient();
-      conference.complete(done);
-    });
-  });
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
 
-  describe("#mute", function(){
-    it("should call mute", function(done){
-      var data = {mute: true };
-      helper.nock().post("/v1/users/FakeUserId/conferences/1", data).reply(200);
-      var conference = new Conference();
-      conference.id = 1;
-      conference.client = helper.createClient();
-      conference.mute(done);
-    });
-  });
+	describe("#get", function () {
+		var item = {
+			id          : "1",
+			from        : "from1",
+			callbackUrl : "http://host1"
+		};
 
-  describe("#playAudio", function(){
-    it("should play audio for a conference", function(done){
-      var data = {fileUrl: "http://host2" };
-      helper.nock().post("/v1/users/FakeUserId/conferences/1/audio", data).reply(200);
-      var conference = new Conference();
-      conference.id = 1;
-      conference.client = helper.createClient();
-      conference.playAudio(data, done);
-    });
-  });
+		it("should return a conference", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/conferences/1").reply(200, item);
+			Conference.get(helper.createClient(), "1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
 
-  describe("#getMembers", function(){
-    var items = [{id: 1}, {id: 2}];
-    it("should return list of members", function(done){
-      helper.nock().get("/v1/users/FakeUserId/conferences/1/members").reply(200, items);
-      var conference = new Conference();
-      conference.id = 1;
-      conference.client = helper.createClient();
-      conference.getMembers(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client; delete i.conferenceId;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should fila on request error", function(done){
-      helper.nock().get("/v1/users/FakeUserId/conferences/1/members").reply(400);
-      var conference = new Conference();
-      conference.id = 1;
-      conference.client = helper.createClient();
-      conference.getMembers(function(err, list){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
 
-  describe("#getMember", function(){
-    var item = {id: 10};
-    it("should return a  member", function(done){
-      helper.nock().get("/v1/users/FakeUserId/conferences/1/members/10").reply(200, item);
-      var conference = new Conference();
-      conference.id = 1;
-      conference.client = helper.createClient();
-      conference.getMember("10", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        delete i.conferenceId;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on request error", function(done){
-      helper.nock().get("/v1/users/FakeUserId/conferences/1/members/10").reply(400);
-      var conference = new Conference();
-      conference.id = 1;
-      conference.client = helper.createClient();
-      conference.getMember("10", function(err, list){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#createMember", function(){
-    var item = {
-        id: "1"
-    };
-    var data = {
-        from: "from1"
-    };
-    it("should create a conference", function(done){
-      helper.nock().post("/v1/users/FakeUserId/conferences/1/members", data).reply(201, "", {"Location": "/v1/users/FakeUserId/conferences/1/members/10"});
-      helper.nock().get("/v1/users/FakeUserId/conferences/1/members/10").reply(200, item);
-      var conference = new Conference();
-      conference.id = 1;
-      conference.client = helper.createClient();
-      conference.createMember(data, function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        delete i.conferenceId;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request error", function(done){
-      helper.nock().post("/v1/users/FakeUserId/conferences/1/members").reply(500);
-      var conference = new Conference();
-      conference.id = 1;
-      conference.client = helper.createClient();
-      conference.createMember(data, function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
+		it("should return a conference (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/conferences/1").reply(200, item);
+			Conference.get("1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/conferences/1").reply(500);
+			Conference.get(helper.createClient(), "1", function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#create", function () {
+		var item = {
+			id          : "1",
+			from        : "from1",
+			callbackUrl : "http://host1"
+		};
+		var data = {
+			from        : "from1",
+			callbackUrl : "http://host1"
+		};
+
+		it("should create a conference", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/conferences", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/conferences/1" });
+			helper.nock().get("/v1/users/FakeUserId/conferences/1").reply(200, item);
+			Conference.create(helper.createClient(), data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should create a conference (with default client)", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/conferences", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/conferences/1" });
+			helper.nock().get("/v1/users/FakeUserId/conferences/1").reply(200, item);
+			Conference.create(data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/conferences").reply(500);
+			Conference.create(helper.createClient(), data, function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#update", function () {
+		it("should update a conference", function (done) {
+			var data = { callbackUrl : "http://host2" };
+			helper.nock().post("/v1/users/FakeUserId/conferences/1", data).reply(200);
+			var conference = new Conference();
+			conference.id = 1;
+			conference.client = helper.createClient();
+			conference.update(data, done);
+		});
+	});
+
+	describe("#complete", function () {
+		it("should update a conference", function (done) {
+			var data = { state : "completed" };
+			helper.nock().post("/v1/users/FakeUserId/conferences/1", data).reply(200);
+			var conference = new Conference();
+			conference.id = 1;
+			conference.client = helper.createClient();
+			conference.complete(done);
+		});
+	});
+
+	describe("#mute", function () {
+		it("should call mute", function (done) {
+			var data = { mute : true };
+			helper.nock().post("/v1/users/FakeUserId/conferences/1", data).reply(200);
+			var conference = new Conference();
+			conference.id = 1;
+			conference.client = helper.createClient();
+			conference.mute(done);
+		});
+	});
+
+	describe("#playAudio", function () {
+		it("should play audio for a conference", function (done) {
+			var data = { fileUrl : "http://host2" };
+			helper.nock().post("/v1/users/FakeUserId/conferences/1/audio", data).reply(200);
+			var conference = new Conference();
+			conference.id = 1;
+			conference.client = helper.createClient();
+			conference.playAudio(data, done);
+		});
+	});
+
+	describe("#getMembers", function () {
+		var items = [ { id : 1 }, { id : 2 } ];
+		it("should return list of members", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/conferences/1/members").reply(200, items);
+			var conference = new Conference();
+			conference.id = 1;
+			conference.client = helper.createClient();
+			conference.getMembers(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client; delete i.conferenceId;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should fila on request error", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/conferences/1/members").reply(400);
+			var conference = new Conference();
+			conference.id = 1;
+			conference.client = helper.createClient();
+			conference.getMembers(function (err, list) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#getMember", function () {
+		var item = { id : 10 };
+		it("should return a  member", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/conferences/1/members/10").reply(200, item);
+			var conference = new Conference();
+			conference.id = 1;
+			conference.client = helper.createClient();
+			conference.getMember("10", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				delete i.conferenceId;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on request error", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/conferences/1/members/10").reply(400);
+			var conference = new Conference();
+			conference.id = 1;
+			conference.client = helper.createClient();
+			conference.getMember("10", function (err, list) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#createMember", function () {
+		var item = {
+			id : "1"
+		};
+		var data = {
+			from : "from1"
+		};
+		it("should create a conference", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/conferences/1/members", data)
+				.reply(201, "", {
+					"Location" : "/v1/users/FakeUserId/conferences/1/members/10"
+				});
+			helper.nock().get("/v1/users/FakeUserId/conferences/1/members/10").reply(200, item);
+			var conference = new Conference();
+			conference.id = 1;
+			conference.client = helper.createClient();
+			conference.createMember(data, function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				delete i.conferenceId;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request error", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/conferences/1/members").reply(500);
+			var conference = new Conference();
+			conference.id = 1;
+			conference.client = helper.createClient();
+			conference.createMember(data, function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
 });

--- a/test/conferenceMember.js
+++ b/test/conferenceMember.js
@@ -3,62 +3,70 @@ var helper = require("./helper");
 var nock = require("nock");
 var ConferenceMember = lib.ConferenceMember;
 
-describe("ConferenceMember", function(){
-  before(function(){
-    nock.disableNetConnect();
-    helper.setupGlobalOptions();
-  });
-  after(function(){
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-  describe("#update", function(){
-    it("should update a member", function(done){
-      var data = { mute: true};
-      helper.nock().post("/v1/users/FakeUserId/conferences/1/members/10", data).reply(200);
-      var member = new ConferenceMember();
-      member.id = 10;
-      member.conferenceId = 1;
-      member.client = helper.createClient();
-      member.update(data, done);
-    });
-    it("should fail on remote request failing", function(done){
-      var data = { mute: true};
-      helper.nock().post("/v1/users/FakeUserId/conferences/1/members/10", data).reply(400);
-      var member = new ConferenceMember();
-      member.id = 10;
-      member.conferenceId = 1;
-      member.client = helper.createClient();
-      member.update(data, function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#playAudio", function(){
-    var data = { fileUrl: "http://host1"};
-    it("should play an audio to a member", function(done){
-      helper.nock().post("/v1/users/FakeUserId/conferences/1/members/10/audio", data).reply(200);
-      var member = new ConferenceMember();
-      member.id = 10;
-      member.conferenceId = 1;
-      member.client = helper.createClient();
-      member.playAudio(data, done);
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().post("/v1/users/FakeUserId/conferences/1/members/10/audio", data).reply(400);
-      var member = new ConferenceMember();
-      member.id = 10;
-      member.conferenceId = 1;
-      member.client = helper.createClient();
-      member.playAudio(data, function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
+describe("ConferenceMember", function () {
+	before(function () {
+		nock.disableNetConnect();
+		helper.setupGlobalOptions();
+	});
+
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	describe("#update", function () {
+		it("should update a member", function (done) {
+			var data = { mute : true };
+			helper.nock().post("/v1/users/FakeUserId/conferences/1/members/10", data).reply(200);
+			var member = new ConferenceMember();
+			member.id = 10;
+			member.conferenceId = 1;
+			member.client = helper.createClient();
+			member.update(data, done);
+		});
+
+		it("should fail on remote request failing", function (done) {
+			var data = { mute : true };
+			helper.nock().post("/v1/users/FakeUserId/conferences/1/members/10", data).reply(400);
+			var member = new ConferenceMember();
+			member.id = 10;
+			member.conferenceId = 1;
+			member.client = helper.createClient();
+			member.update(data, function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#playAudio", function () {
+		var data = { fileUrl : "http://host1" };
+
+		it("should play an audio to a member", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/conferences/1/members/10/audio", data).reply(200);
+			var member = new ConferenceMember();
+			member.id = 10;
+			member.conferenceId = 1;
+			member.client = helper.createClient();
+			member.playAudio(data, done);
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/conferences/1/members/10/audio", data).reply(400);
+			var member = new ConferenceMember();
+			member.id = 10;
+			member.conferenceId = 1;
+			member.client = helper.createClient();
+			member.playAudio(data, function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
 });

--- a/test/domain.js
+++ b/test/domain.js
@@ -1,218 +1,262 @@
 "use strict";
+
 var lib = require("../");
 var helper = require("./helper");
 var nock = require("nock");
 var Domain = lib.Domain;
 
-describe("Domain", function(){
-  before(function(){
-    nock.disableNetConnect();
-    helper.setupGlobalOptions();
-  });
-  after(function(){
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-  describe("#list", function(){
-    var items = [
-    {
-        id: "1",
-        name: "domain1"
-    },
-    {
-        id: "2",
-        name: "domain2"
-    }
-    ];
-    it("should return domains", function(done){
-      helper.nock().get("/v1/users/FakeUserId/domains").reply(200, items);
-      Domain.list(helper.createClient(), function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){ delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return a domain (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/domains").reply(200, items);
-      Domain.list(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){ delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().get("/v1/users/FakeUserId/domains").reply(500);
-      Domain.list(helper.createClient(),  function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#create", function(){
-    var item = {
-        id: "1",
-        name: "domain1",
-        description: "description1"
-    };
-    var data = {
-        name: "domain1",
-        description: "description1"
-    };
-    it("should create a domain", function(done){
-      helper.nock().post("/v1/users/FakeUserId/domains", data).reply(201, "", {"Location": "/v1/users/FakeUserId/domains/1"});
-      helper.nock().get("/v1/users/FakeUserId/domains/1").reply(200, item);
-      Domain.create(helper.createClient(), data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should create a domain (with default client)", function(done){
-      helper.nock().post("/v1/users/FakeUserId/domains", data).reply(201, "", {"Location": "/v1/users/FakeUserId/domains/1"});
-      helper.nock().get("/v1/users/FakeUserId/domains/1").reply(200, item);
-      Domain.create(data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().post("/v1/users/FakeUserId/domains").reply(500);
-      Domain.create(helper.createClient(), data, function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#delete", function(){
-    it("should remove a domain", function(done){
-      helper.nock().delete("/v1/users/FakeUserId/domains/1").reply(200);
-      var domain = new Domain();
-      domain.id = 1;
-      domain.client = helper.createClient();
-      domain.delete(done);
-    });
-  });
+describe("Domain", function () {
+	before(function () {
+		nock.disableNetConnect();
+		helper.setupGlobalOptions();
+	});
 
-  describe("#getEndPoints", function(){
-    var items = [{id: 1}, {id: 2}];
-    it("should return list of endPoints", function(done){
-      helper.nock().get("/v1/users/FakeUserId/domains/1/endpoints").reply(200, items);
-      var domain = new Domain();
-      domain.id = 1;
-      domain.client = helper.createClient();
-      domain.getEndPoints(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client; delete i.domainId;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should fila on request error", function(done){
-      helper.nock().get("/v1/users/FakeUserId/domains/1/endpoints").reply(400);
-      var domain = new Domain();
-      domain.id = 1;
-      domain.client = helper.createClient();
-      domain.getEndPoints(function(err, list){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
 
-  describe("#getEndPoint", function(){
-    var item = {id: 10};
-    it("should return an endpoint", function(done){
-      helper.nock().get("/v1/users/FakeUserId/domains/1/endpoints/10").reply(200, item);
-      var domain = new Domain();
-      domain.id = 1;
-      domain.client = helper.createClient();
-      domain.getEndPoint("10", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        delete i.domainId;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on request error", function(done){
-      helper.nock().get("/v1/users/FakeUserId/domains/1/endpoints/10").reply(400);
-      var domain = new Domain();
-      domain.id = 1;
-      domain.client = helper.createClient();
-      domain.getEndPoint("10", function(err, list){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#createEndPoint", function(){
-    var item = {
-        id: "1"
-    };
-    var data = {
-        name: "point1"
-    };
-    it("should create an endpoint", function(done){
-      helper.nock().post("/v1/users/FakeUserId/domains/1/endpoints", data).reply(201, "", {"Location": "/v1/users/FakeUserId/domains/1/endpoints/10"});
-      helper.nock().get("/v1/users/FakeUserId/domains/1/endpoints/10").reply(200, item);
-      var domain = new Domain();
-      domain.id = 1;
-      domain.client = helper.createClient();
-      domain.createEndPoint(data, function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        delete i.domainId;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request error", function(done){
-      helper.nock().post("/v1/users/FakeUserId/domains/1/endpoints").reply(500);
-      var domain = new Domain();
-      domain.id = 1;
-      domain.client = helper.createClient();
-      domain.createEndPoint(data, function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#deleteEndPoint", function(){
-    it("should delete an endPoint", function(done){
-      helper.nock().delete("/v1/users/FakeUserId/domains/1/endpoints/10").reply(200);
-      var domain = new Domain();
-      domain.id = 1;
-      domain.client = helper.createClient();
-      domain.deleteEndPoint("10", done);
-    });
-  });
+	describe("#list", function () {
+		var items = [ {
+			id   : "1",
+			name : "domain1"
+		}, {
+			id   : "2",
+			name : "domain2"
+		} ];
+
+		it("should return domains", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/domains").reply(200, items);
+			Domain.list(helper.createClient(), function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return a domain (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/domains").reply(200, items);
+			Domain.list(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/domains").reply(500);
+			Domain.list(helper.createClient(),  function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#create", function () {
+		var item = {
+			id          : "1",
+			name        : "domain1",
+			description : "description1"
+		};
+
+		var data = {
+			name        : "domain1",
+			description : "description1"
+		};
+
+		it("should create a domain", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/domains", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/domains/1" });
+			helper.nock().get("/v1/users/FakeUserId/domains/1").reply(200, item);
+			Domain.create(helper.createClient(), data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should create a domain (with default client)", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/domains", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/domains/1" });
+			helper.nock().get("/v1/users/FakeUserId/domains/1").reply(200, item);
+			Domain.create(data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/domains").reply(500);
+			Domain.create(helper.createClient(), data, function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#delete", function () {
+		it("should remove a domain", function (done) {
+			helper.nock().delete("/v1/users/FakeUserId/domains/1").reply(200);
+			var domain = new Domain();
+			domain.id = 1;
+			domain.client = helper.createClient();
+			domain.delete(done);
+		});
+	});
+
+	describe("#getEndPoints", function () {
+		var items = [ { id : 1 }, { id : 2 } ];
+		it("should return list of endPoints", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/domains/1/endpoints").reply(200, items);
+			var domain = new Domain();
+			domain.id = 1;
+			domain.client = helper.createClient();
+			domain.getEndPoints(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client; delete i.domainId;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should fila on request error", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/domains/1/endpoints").reply(400);
+			var domain = new Domain();
+			domain.id = 1;
+			domain.client = helper.createClient();
+			domain.getEndPoints(function (err, list) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#getEndPoint", function () {
+
+		var item = { id : 10 };
+
+		it("should return an endpoint", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/domains/1/endpoints/10").reply(200, item);
+			var domain = new Domain();
+			domain.id = 1;
+			domain.client = helper.createClient();
+			domain.getEndPoint("10", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				delete i.domainId;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on request error", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/domains/1/endpoints/10").reply(400);
+			var domain = new Domain();
+			domain.id = 1;
+			domain.client = helper.createClient();
+			domain.getEndPoint("10", function (err, list) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#createEndPoint", function () {
+		var item = {
+			id : "1"
+		};
+
+		var data = {
+			name : "point1"
+		};
+
+		it("should create an endpoint", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/domains/1/endpoints", data)
+				.reply(201, "", {
+					"Location" : "/v1/users/FakeUserId/domains/1/endpoints/10"
+				});
+			helper.nock().get("/v1/users/FakeUserId/domains/1/endpoints/10").reply(200, item);
+			var domain = new Domain();
+			domain.id = 1;
+			domain.client = helper.createClient();
+			domain.createEndPoint(data, function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				delete i.domainId;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request error", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/domains/1/endpoints").reply(500);
+			var domain = new Domain();
+			domain.id = 1;
+			domain.client = helper.createClient();
+			domain.createEndPoint(data, function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#deleteEndPoint", function () {
+		it("should delete an endPoint", function (done) {
+			helper.nock().delete("/v1/users/FakeUserId/domains/1/endpoints/10").reply(200);
+			var domain = new Domain();
+			domain.id = 1;
+			domain.client = helper.createClient();
+			domain.deleteEndPoint("10", done);
+		});
+	});
 });

--- a/test/endPoint.js
+++ b/test/endPoint.js
@@ -1,56 +1,62 @@
 "use strict";
+
 var lib = require("../");
 var helper = require("./helper");
 var nock = require("nock");
 var EndPoint = lib.EndPoint;
 
-describe("EndPoint", function(){
-  before(function(){
-    nock.disableNetConnect();
-    helper.setupGlobalOptions();
-  });
-  after(function(){
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-  describe("#delete", function(){
-    it("should remove an endpoint", function(done){
-      helper.nock().delete("/v1/users/FakeUserId/domains/1/endpoints/10").reply(200);
-      var endPoint = new EndPoint();
-      endPoint.domainId = 1;
-      endPoint.id = 10;
-      endPoint.client = helper.createClient();
-      endPoint.delete(done);
-    });
-  });
-  describe("#createAuthToken - success", function(){
-    it("should create an auth token", function(done){
-      var tokenData = {
-        token: '1234567890',
-        expires: 86400
-      };
-      helper.nock().post("/v1/users/FakeUserId/domains/1/endpoints/10/tokens").reply(200, tokenData);
-      var endPoint = new EndPoint();
-      endPoint.domainId = 1;
-      endPoint.id = 10;
-      endPoint.client = helper.createClient();
-      endPoint.createAuthToken(function(err, data){
-        data.should.eql(tokenData);
-        done(err);
-      });
-    });
-  });
-  describe("#createAuthToken - failure", function(){
-    it("should fail", function(done){
-      helper.nock().post("/v1/users/FakeUserId/domains/1/endpoints/10/tokens").reply(400);
-      var endPoint = new EndPoint();
-      endPoint.domainId = 1;
-      endPoint.id = 10;
-      endPoint.client = helper.createClient();
-      endPoint.createAuthToken(function(err, data){
-        err.should.not.eql(null);
-        done();
-      });
-    });
-  });
+describe("EndPoint", function () {
+
+	before(function () {
+		nock.disableNetConnect();
+		helper.setupGlobalOptions();
+	});
+
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	describe("#delete", function () {
+		it("should remove an endpoint", function (done) {
+			helper.nock().delete("/v1/users/FakeUserId/domains/1/endpoints/10").reply(200);
+			var endPoint = new EndPoint();
+			endPoint.domainId = 1;
+			endPoint.id = 10;
+			endPoint.client = helper.createClient();
+			endPoint.delete(done);
+		});
+	});
+
+	describe("#createAuthToken - success", function () {
+		it("should create an auth token", function (done) {
+			var tokenData = {
+				token   : "1234567890",
+				expires : 86400
+			};
+			helper.nock().post("/v1/users/FakeUserId/domains/1/endpoints/10/tokens").reply(200, tokenData);
+			var endPoint = new EndPoint();
+			endPoint.domainId = 1;
+			endPoint.id = 10;
+			endPoint.client = helper.createClient();
+			endPoint.createAuthToken(function (err, data) {
+				data.should.eql(tokenData);
+				done(err);
+			});
+		});
+	});
+
+	describe("#createAuthToken - failure", function () {
+		it("should fail", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/domains/1/endpoints/10/tokens").reply(400);
+			var endPoint = new EndPoint();
+			endPoint.domainId = 1;
+			endPoint.id = 10;
+			endPoint.client = helper.createClient();
+			endPoint.createAuthToken(function (err, data) {
+				err.should.not.eql(null);
+				done();
+			});
+		});
+	});
 });

--- a/test/error.js
+++ b/test/error.js
@@ -1,88 +1,105 @@
 var lib = require("../");
 var helper = require("./helper");
 var nock = require("nock");
-var Error = lib.Error;
+var BWError = require("../lib/error");
 
-describe("Error", function(){
-  before(function(){
-    nock.disableNetConnect();
-    helper.setupGlobalOptions();
-  });
-  after(function(){
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-  describe("#get", function(){
-    var item = {
-      id: "100",
-      message: "prepay",
-      category: "bad_request"
-    };
-    it("should return error info", function(done){
-      helper.nock().get("/v1/users/FakeUserId/errors/100").reply(200, item);
-      Error.get(helper.createClient(), "100", function(err, i){
-        if(err){
-          return done(err);
-        }
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should return error info (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/errors/100").reply(200, item);
-      Error.get("100", function(err, i){
-        if(err){
-          return done(err);
-        }
-        i.should.eql(item);
-        done();
-      });
-    });
-  });
-  describe("#list", function(){
-    var items = [
-      {id: 1, message: "error1"},
-      {id: 2, message: "error2"}
-    ];
-    it("should return errors", function(done){
-      helper.nock().get("/v1/users/FakeUserId/errors?page=1").reply(200, items);
-      Error.list(helper.createClient(), {page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return transactions (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/errors?page=1").reply(200, items);
-      Error.list({page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return transactions (without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/errors").reply(200, items);
-      Error.list(helper.createClient(), function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return transactions (with default client, without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/errors").reply(200, items);
-      Error.list(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-  });
+describe("BWError", function () {
+
+	before(function () {
+		nock.disableNetConnect();
+		helper.setupGlobalOptions();
+	});
+
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	describe("#get", function () {
+
+		var item = {
+			id       : "100",
+			message  : "prepay",
+			category : "bad_request"
+		};
+
+		it("should return BWError info", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/errors/100").reply(200, item);
+			BWError.get(helper.createClient(), "100", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should return BWError info (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/errors/100").reply(200, item);
+			BWError.get("100", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				i.should.eql(item);
+				done();
+			});
+		});
+	});
+
+	describe("#list", function () {
+
+		var items = [
+			{ id : 1, message : "BWError1" },
+			{ id : 2, message : "BWError2" } ];
+
+		it("should return BWErrors", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/errors?page=1").reply(200, items);
+			BWError.list(helper.createClient(), { page : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return transactions (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/errors?page=1").reply(200, items);
+			BWError.list({ page : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return transactions (without query)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/errors").reply(200, items);
+			BWError.list(helper.createClient(), function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return transactions (with default client, without query)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/errors").reply(200, items);
+			BWError.list(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+	});
 });

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,17 +1,18 @@
 var Client = require("../").Client;
 var nock = require("nock");
+
 module.exports = {
-  setupGlobalOptions: function(){
-    Client.globalOptions.userId = "FakeUserId";
-    Client.globalOptions.apiToken = "FakeApiToken";
-    Client.globalOptions.apiSecret = "FakeApiSecret";
-  },
+	setupGlobalOptions : function () {
+		Client.globalOptions.userId = "FakeUserId";
+		Client.globalOptions.apiToken = "FakeApiToken";
+		Client.globalOptions.apiSecret = "FakeApiSecret";
+	},
 
-  createClient: function(){
-    return new Client("FakeUserId", "FakeApiToken", "FakeApiSecret");
-  },
+	createClient : function () {
+		return new Client("FakeUserId", "FakeApiToken", "FakeApiSecret");
+	},
 
-  nock: function(){
-    return nock("https://api.catapult.inetwork.com");
-  }
+	nock : function () {
+		return nock("https://api.catapult.inetwork.com");
+	}
 };

--- a/test/media.js
+++ b/test/media.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var fs = require("fs");
 var os = require("os");
 var path = require("path");
@@ -8,219 +10,261 @@ var Media = lib.Media;
 
 var tmpFile = path.join(os.tmpdir(), "dest.txt");
 
-describe("Media", function(){
-  before(function(){
-    nock.disableNetConnect();
-    helper.setupGlobalOptions();
-  });
-  after(function(){
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-  describe("#list", function(){
-    var items = [
-      {mediaName: "file1", content: "url1", contentLength: 100},
-      {mediaName: "file2", content: "url2", contentLength: 200}
-    ];
-    it("should return list of files", function(done){
-      helper.nock().get("/v1/users/FakeUserId/media?page=1").reply(200, items);
-      Media.list(helper.createClient(), {page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return account info (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/media?page=1").reply(200, items);
-      Media.list({page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of files (without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/media").reply(200, items);
-      Media.list(helper.createClient(), function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return account info (with default client, without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/media").reply(200, items);
-      Media.list(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-  });
-  describe("#delete", function(){
-    it("should delete file from the server", function(done){
-      helper.nock().delete("/v1/users/FakeUserId/media/fileName").reply(200);
-      Media.delete(helper.createClient(), "fileName", done);
-    });
-    it("should delete file from the server (with default client)", function(done){
-      helper.nock().delete("/v1/users/FakeUserId/media/fileName").reply(200);
-      Media.delete("fileName", done);
-    });
-  });
-  describe("#getInfo", function(){
-    it("should get info on file from server", function(done){
-      helper.nock().head("/v1/users/FakeUserId/media/file1").reply(200, "OK", {'Content-Length': 100});
-      Media.getInfo(helper.createClient(), "file1", function(err, result) {
-        if (err){
-          return done(err);
-        }
-        result.contentLength.should.eql(100);
-        done();
-      });
-    });
-    it("should get info on file from server (with default client)", function(done){
-      helper.nock().head("/v1/users/FakeUserId/media/file1").reply(200, "OK", {'Content-Length': 100});
-      Media.getInfo("file1", function(err, result){
-        if (err){
-          return done(err);
-        }
-        result.contentLength.should.eql(100);
-        done();
-      });
-    });
-    it("should error on getting info on non existing file", function(done){
-        helper.nock().head("/v1/users/FakeUserId/media/nonexistingfile").reply(404);
-        Media.getInfo("nonexistingfile", function(err, result){
-          err.httpStatus.should.eql(404);
-          done();
-        });
-      });
-  });
-  describe("#download", function(){
-    beforeEach(function(){
-      helper.nock().get("/v1/users/FakeUserId/media/fileName").reply(200, "12345", {"Content-Type": "text/plain"});
-    });
-    afterEach(function(done){
-      nock.cleanAll();
-      fs.unlink(tmpFile, done);
-    });
-    it("should download file to destination file", function(done){
-      var stream = Media.download(helper.createClient(), "fileName", tmpFile);
-      stream.on("finish", function(){
-        fs.readFile(tmpFile, "utf8", function(err, text){
-          if(err){
-            done(err);
-          }
-          text.should.equal("12345");
-          done();
-        });
-      });
-    });
-    it("should download file to destination file (with default client)", function(done){
-      var stream = Media.download("fileName", tmpFile);
-      stream.on("finish", function(){
-        fs.readFile(tmpFile, "utf8", function(err, text){
-          if(err){
-            done(err);
-          }
-          text.should.equal("12345");
-          done();
-        });
-      });
-    });
-    it("should download file to destination stream", function(done){
-      var outputStream = fs.createWriteStream(tmpFile);
-      var stream = Media.download(helper.createClient(), "fileName", outputStream);
-      stream.on("finish", function(){
-        fs.readFile(tmpFile, "utf8", function(err, text){
-          if(err){
-            done(err);
-          }
-          text.should.equal("12345");
-          done();
-        });
-      });
-    });
-    it("should download file to destination stream (with default client)", function(done){
-      var outputStream = fs.createWriteStream(tmpFile);
-      var stream = Media.download("fileName", outputStream);
-      stream.on("finish", function(){
-        fs.readFile(tmpFile, "utf8", function(err, text){
-          if(err){
-            done(err);
-          }
-          text.should.equal("12345");
-          done();
-        });
-      });
-    });
-    it("should allow access to request", function(done){
-      var outputStream = fs.createWriteStream(tmpFile);
-      var stream = Media.download(helper.createClient(), "fileName").pipe(outputStream);
-      stream.on("finish", function(){
-        fs.readFile(tmpFile, "utf8", function(err, text){
-          if(err){
-            done(err);
-          }
-          text.should.equal("12345");
-          done();
-        });
-      });
-    });
-    it("should allow access to request (with default client)", function(done){
-      var outputStream = fs.createWriteStream(tmpFile);
-      var stream = Media.download("fileName").pipe(outputStream);
-      stream.on("finish", function(){
-        fs.readFile(tmpFile, "utf8", function(err, text){
-          if(err){
-            done(err);
-          }
-          text.should.equal("12345");
-          done();
-        });
-      });
-    });
-  });
-  describe("#upload", function(){
-    before(function(done){
-      fs.writeFile(tmpFile, "12345", "utf8", done);
-    });
-    beforeEach(function(){
-      helper.nock().put("/v1/users/FakeUserId/media/fileName", "12345", {"Content-Type": "text/plain"}).reply(200);
-    });
-    it("should upload file to the server", function(done){
-      Media.upload(helper.createClient(), "fileName", tmpFile, "text/plain", done);
-    });
-    it("should upload file to the server (with default client)", function(done){
-      Media.upload("fileName", tmpFile, "text/plain", done);
-    });
-    it("should upload file to the server (without media type)", function(done){
-      helper.nock().put("/v1/users/FakeUserId/media/fileName", "12345", {"Content-Type": "application/octet-stream"}).reply(200);
-      Media.upload(helper.createClient(), "fileName", tmpFile, done);
-    });
-    it("should upload file to the server (with default client, without media type)", function(done){
-      helper.nock().put("/v1/users/FakeUserId/media/fileName", "12345", {"Content-Type": "application/octet-stream"}).reply(200);
-      Media.upload("fileName", tmpFile, done);
-    });
-    it("should upload stream to the server", function(done){
-      Media.upload(helper.createClient(), "fileName", fs.createReadStream(tmpFile), "text/plain", done);
-    });
-    it("should upload buffer to the server", function(done){
-      Media.upload(helper.createClient(), "fileName", new Buffer("12345", "utf8"), "text/plain", done);
-    });
-    it("should fail for invalid data to upload", function(done){
-      Media.upload(helper.createClient(), "fileName", {data: 1}, "text/plain", function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
+describe("Media", function () {
+	before(function () {
+		nock.disableNetConnect();
+		helper.setupGlobalOptions();
+	});
+
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	describe("#list", function () {
+		var items = [
+			{ mediaName : "file1", content : "url1", contentLength : 100 },
+			{ mediaName : "file2", content : "url2", contentLength : 200 } ];
+
+		it("should return list of files", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/media?page=1").reply(200, items);
+			Media.list(helper.createClient(), { page : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return account info (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/media?page=1").reply(200, items);
+			Media.list({ page : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return list of files (without query)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/media").reply(200, items);
+			Media.list(helper.createClient(), function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return account info (with default client, without query)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/media").reply(200, items);
+			Media.list(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+	});
+
+	describe("#delete", function () {
+		it("should delete file from the server", function (done) {
+			helper.nock().delete("/v1/users/FakeUserId/media/fileName").reply(200);
+			Media.delete(helper.createClient(), "fileName", done);
+		});
+
+		it("should delete file from the server (with default client)", function (done) {
+			helper.nock().delete("/v1/users/FakeUserId/media/fileName").reply(200);
+			Media.delete("fileName", done);
+		});
+	});
+
+	describe("#getInfo", function () {
+		it("should get info on file from server", function (done) {
+			helper.nock().head("/v1/users/FakeUserId/media/file1").reply(200, "OK", { "Content-Length" : 100 });
+			Media.getInfo(helper.createClient(), "file1", function (err, result) {
+				if (err) {
+					return done(err);
+				}
+
+				result.contentLength.should.eql(100);
+				done();
+			});
+		});
+
+		it("should get info on file from server (with default client)", function (done) {
+			helper.nock().head("/v1/users/FakeUserId/media/file1").reply(200, "OK", { "Content-Length" : 100 });
+			Media.getInfo("file1", function (err, result) {
+				if (err) {
+					return done(err);
+				}
+
+				result.contentLength.should.eql(100);
+				done();
+			});
+		});
+
+		it("should error on getting info on non existing file", function (done) {
+			helper.nock().head("/v1/users/FakeUserId/media/nonexistingfile").reply(404);
+			Media.getInfo("nonexistingfile", function (err, result) {
+				err.httpStatus.should.eql(404);
+				done();
+			});
+		});
+	});
+
+	describe("#download", function () {
+		beforeEach(function () {
+			helper.nock().get("/v1/users/FakeUserId/media/fileName").reply(200, "12345", { "Content-Type" : "text/plain" });
+		});
+
+		afterEach(function (done) {
+			nock.cleanAll();
+			fs.unlink(tmpFile, done);
+		});
+
+		it("should download file to destination file", function (done) {
+			var stream = Media.download(helper.createClient(), "fileName", tmpFile);
+			stream.on("finish", function () {
+				fs.readFile(tmpFile, "utf8", function (err, text) {
+					if (err) {
+						done(err);
+					}
+
+					text.should.equal("12345");
+					done();
+				});
+			});
+		});
+
+		it("should download file to destination file (with default client)", function (done) {
+			var stream = Media.download("fileName", tmpFile);
+			stream.on("finish", function () {
+				fs.readFile(tmpFile, "utf8", function (err, text) {
+					if (err) {
+						done(err);
+					}
+
+					text.should.equal("12345");
+					done();
+				});
+			});
+		});
+
+		it("should download file to destination stream", function (done) {
+			var outputStream = fs.createWriteStream(tmpFile);
+			var stream = Media.download(helper.createClient(), "fileName", outputStream);
+			stream.on("finish", function () {
+				fs.readFile(tmpFile, "utf8", function (err, text) {
+					if (err) {
+						done(err);
+					}
+
+					text.should.equal("12345");
+					done();
+				});
+			});
+		});
+
+		it("should download file to destination stream (with default client)", function (done) {
+			var outputStream = fs.createWriteStream(tmpFile);
+			var stream = Media.download("fileName", outputStream);
+			stream.on("finish", function () {
+				fs.readFile(tmpFile, "utf8", function (err, text) {
+					if (err) {
+						done(err);
+					}
+
+					text.should.equal("12345");
+					done();
+				});
+			});
+		});
+
+		it("should allow access to request", function (done) {
+			var outputStream = fs.createWriteStream(tmpFile);
+			var stream = Media.download(helper.createClient(), "fileName").pipe(outputStream);
+			stream.on("finish", function () {
+				fs.readFile(tmpFile, "utf8", function (err, text) {
+					if (err) {
+						done(err);
+					}
+
+					text.should.equal("12345");
+					done();
+				});
+			});
+		});
+
+		it("should allow access to request (with default client)", function (done) {
+			var outputStream = fs.createWriteStream(tmpFile);
+			var stream = Media.download("fileName").pipe(outputStream);
+			stream.on("finish", function () {
+				fs.readFile(tmpFile, "utf8", function (err, text) {
+					if (err) {
+						done(err);
+					}
+
+					text.should.equal("12345");
+					done();
+				});
+			});
+		});
+	});
+
+	describe("#upload", function () {
+		before(function (done) {
+			fs.writeFile(tmpFile, "12345", "utf8", done);
+		});
+
+		beforeEach(function () {
+			helper.nock().put("/v1/users/FakeUserId/media/fileName", "12345", { "Content-Type" : "text/plain" }).reply(200);
+		});
+
+		it("should upload file to the server", function (done) {
+			Media.upload(helper.createClient(), "fileName", tmpFile, "text/plain", done);
+		});
+
+		it("should upload file to the server (with default client)", function (done) {
+			Media.upload("fileName", tmpFile, "text/plain", done);
+		});
+
+		it("should upload file to the server (without media type)", function (done) {
+			helper.nock().put("/v1/users/FakeUserId/media/fileName", "12345",
+				{ "Content-Type" : "application/octet-stream" }).reply(200);
+			Media.upload(helper.createClient(), "fileName", tmpFile, done);
+		});
+
+		it("should upload file to the server (with default client, without media type)", function (done) {
+			helper.nock().put("/v1/users/FakeUserId/media/fileName", "12345",
+				{ "Content-Type" : "application/octet-stream" }).reply(200);
+			Media.upload("fileName", tmpFile, done);
+		});
+
+		it("should upload stream to the server", function (done) {
+			Media.upload(helper.createClient(), "fileName", fs.createReadStream(tmpFile), "text/plain", done);
+		});
+
+		it("should upload buffer to the server", function (done) {
+			Media.upload(helper.createClient(), "fileName", new Buffer("12345", "utf8"), "text/plain", done);
+		});
+
+		it("should fail for invalid data to upload", function (done) {
+			Media.upload(helper.createClient(), "fileName", { data : 1 }, "text/plain", function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
 });

--- a/test/message.js
+++ b/test/message.js
@@ -1,192 +1,245 @@
+"use strict";
+
 var lib = require("../");
 var helper = require("./helper");
 var nock = require("nock");
 var Message = lib.Message;
 
-describe("Message", function(){
-  before(function(){
-    nock.disableNetConnect();
-    helper.setupGlobalOptions();
-  });
-  after(function(){
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-  describe("#list", function(){
-    var items = [{
-        id: "1",
-        from: "from1",
-        to: "to1",
-        text: "text1"
-      },{
-        id: "2",
-        from: "from2",
-        to: "to2",
-        text: "text2"
-      }
-    ];
-    it("should return list of messages", function(done){
-      helper.nock().get("/v1/users/FakeUserId/messages?page=1").reply(200, items);
-      Message.list(helper.createClient(), {page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        new Message();
-        done();
-      });
-    });
-    it("should return list of messages (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/messages?page=1").reply(200, items);
-      Message.list({page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of messages (without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/messages").reply(200, items);
-      Message.list(helper.createClient(),  function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of messages (with default client, without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/messages").reply(200, items);
-      Message.list(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should fail if request failed", function(done){
-      helper.nock().get("/v1/users/FakeUserId/messages").reply(500);
-      Message.list(helper.createClient(),  function(err, list){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#get", function(){
-    var item = {
-      id: "1",
-      from: "from1",
-      to: "to1",
-      text: "message"
-    };
-    it("should return a message", function(done){
-      helper.nock().get("/v1/users/FakeUserId/messages/1").reply(200, item);
-      Message.get(helper.createClient(), "1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should return a message (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/messages/1").reply(200, item);
-      Message.get("1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().get("/v1/users/FakeUserId/messages/1").reply(500);
-      Message.get(helper.createClient(), "1", function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#create", function(){
-    var item = {
-      id: "1",
-      from: "from",
-      to: "to",
-      text: "text"
-    };
-    var data = {
-      from: "from",
-      to: "to",
-      text: "text"
-    };
-    it("should create a message", function(done){
-      helper.nock().post("/v1/users/FakeUserId/messages", data).reply(201, "", {"Location": "/v1/users/FakeUserId/messages/1"});
-      helper.nock().get("/v1/users/FakeUserId/messages/1").reply(200, item);
-      Message.create(helper.createClient(), data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should create list of messages", function(done){
-      var data = [{from: "from1", to: "to1", text: "text1"}, {from: "from2", to: "to2", text: "text2"}];
-      helper.nock().post("/v1/users/FakeUserId/messages", data).reply(200, [{result: "error", error: {message: "Error"}}, {result: "accepted", location: "/v1/users/FakeUserId/messages/1"}]);
-      Message.create(helper.createClient(), data,  function(err, statuses){
-        if(err){
-          return done(err);
-        }
-        statuses[0].error.message.should.equal("Error");
-        statuses[1].id.should.equal("1")
-        done();
-      });
-    });
-    it("should create a message (with default client)", function(done){
-      helper.nock().post("/v1/users/FakeUserId/messages", data).reply(201, "", {"Location": "/v1/users/FakeUserId/messages/1"});
-      helper.nock().get("/v1/users/FakeUserId/messages/1").reply(200, item);
-      Message.create(data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should create list of messages (with default client)", function(done){
-      var data = [{from: "from1", to: "to1", text: "text1"}, {from: "from2", to: "to2", text: "text2"}];
-      helper.nock().post("/v1/users/FakeUserId/messages", data).reply(200, [{result: "accepted"}, {result: "accepted", location: "/v1/users/FakeUserId/messages/1"}]);
-      Message.create( data,  function(err, statuses){
-        if(err){
-          return done(err);
-        }
-        statuses[0].error.should.be.ok;
-        statuses[1].id.should.equal("1")
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().post("/v1/users/FakeUserId/messages").reply(500);
-      Message.create(helper.createClient(), data, function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
+describe("Message", function () {
+	before(function () {
+		nock.disableNetConnect();
+		helper.setupGlobalOptions();
+	});
+
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	describe("#list", function () {
+		var items = [ {
+			id   : "1",
+			from : "from1",
+			to   : "to1",
+			text : "text1"
+		}, {
+			id   : "2",
+			from : "from2",
+			to   : "to2",
+			text : "text2"
+		} ];
+
+		it("should return list of messages", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/messages?page=1").reply(200, items);
+			Message.list(helper.createClient(), { page : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				new Message();
+				done();
+			});
+		});
+
+		it("should return list of messages (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/messages?page=1").reply(200, items);
+			Message.list({ page : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return list of messages (without query)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/messages").reply(200, items);
+			Message.list(helper.createClient(),  function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return list of messages (with default client, without query)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/messages").reply(200, items);
+			Message.list(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should fail if request failed", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/messages").reply(500);
+			Message.list(helper.createClient(),  function (err, list) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#get", function () {
+		var item = {
+			id   : "1",
+			from : "from1",
+			to   : "to1",
+			text : "message"
+		};
+
+		it("should return a message", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/messages/1").reply(200, item);
+			Message.get(helper.createClient(), "1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should return a message (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/messages/1").reply(200, item);
+			Message.get("1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/messages/1").reply(500);
+			Message.get(helper.createClient(), "1", function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#create", function () {
+		var item = {
+			id   : "1",
+			from : "from",
+			to   : "to",
+			text : "text"
+		};
+
+		var data = {
+			from : "from",
+			to   : "to",
+			text : "text"
+		};
+
+		it("should create a message", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/messages", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/messages/1" });
+			helper.nock().get("/v1/users/FakeUserId/messages/1").reply(200, item);
+			Message.create(helper.createClient(), data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should create list of messages", function (done) {
+			var data = [ { from : "from1", to : "to1", text : "text1" }, { from : "from2", to : "to2", text : "text2" } ];
+			helper.nock().post("/v1/users/FakeUserId/messages", data)
+				.reply(200, [
+					{ result : "error", error : { message : "Error" } },
+					{ result : "accepted", location : "/v1/users/FakeUserId/messages/1" } ]);
+			Message.create(helper.createClient(), data,  function (err, statuses) {
+				if (err) {
+					return done(err);
+				}
+
+				statuses[0].error.message.should.equal("Error");
+				statuses[1].id.should.equal("1");
+				done();
+			});
+		});
+
+		it("should create a message (with default client)", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/messages", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/messages/1" });
+			helper.nock().get("/v1/users/FakeUserId/messages/1").reply(200, item);
+			Message.create(data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should create list of messages (with default client)", function (done) {
+			var data = [ { from : "from1", to : "to1", text : "text1" }, { from : "from2", to : "to2", text : "text2" } ];
+			helper.nock().post("/v1/users/FakeUserId/messages", data)
+				.reply(200, [
+					{ result : "accepted" },
+					{ result : "accepted", location : "/v1/users/FakeUserId/messages/1" }
+				]);
+			Message.create(data,  function (err, statuses) {
+				if (err) {
+					return done(err);
+				}
+
+				statuses[0].error.should.be.ok;
+				statuses[1].id.should.equal("1");
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/messages").reply(500);
+			Message.create(helper.createClient(), data, function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
 });

--- a/test/numberInfo.js
+++ b/test/numberInfo.js
@@ -1,40 +1,48 @@
+"use strict";
+
 var lib = require("../");
 var helper = require("./helper");
 var nock = require("nock");
 var NumberInfo = lib.NumberInfo;
 
-describe("NumberInfo", function(){
-  before(function(){
-    nock.disableNetConnect();
-    helper.setupGlobalOptions();
-  });
-  after(function(){
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-  describe("#get", function(){
-    var item = {
-      number: "11111"
-    };
-    it("should return number info", function(done){
-      helper.nock().get("/v1/phoneNumbers/numberInfo/11111").reply(200, item);
-      NumberInfo.get(helper.createClient(), "11111", function(err, i){
-        if(err){
-          return done(err);
-        }
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should return numberInfo info (with default client)", function(done){
-      helper.nock().get("/v1/phoneNumbers/numberInfo/11111").reply(200, item);
-      NumberInfo.get("11111", function(err, i){
-        if(err){
-          return done(err);
-        }
-        i.should.eql(item);
-        done();
-      });
-    });
-  });
+describe("NumberInfo", function () {
+	before(function () {
+		nock.disableNetConnect();
+		helper.setupGlobalOptions();
+	});
+
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	describe("#get", function () {
+		var item = {
+			number : "11111"
+		};
+
+		it("should return number info", function (done) {
+			helper.nock().get("/v1/phoneNumbers/numberInfo/11111").reply(200, item);
+			NumberInfo.get(helper.createClient(), "11111", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should return numberInfo info (with default client)", function (done) {
+			helper.nock().get("/v1/phoneNumbers/numberInfo/11111").reply(200, item);
+			NumberInfo.get("11111", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				i.should.eql(item);
+				done();
+			});
+		});
+	});
 });

--- a/test/phoneNumber.js
+++ b/test/phoneNumber.js
@@ -1,181 +1,223 @@
+"use strict";
+
 var lib = require("../");
 var helper = require("./helper");
 var nock = require("nock");
 var PhoneNumber = lib.PhoneNumber;
 
-describe("PhoneNumber", function(){
-  before(function(){
-    nock.disableNetConnect();
-    helper.setupGlobalOptions();
-  });
-  after(function(){
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-  describe("#list", function(){
-    var items = [{
-        id: "1",
-        number: "111111",
-        numberState: "enabled",
-      },{
-        id: "2",
-        number: "222222",
-        numberState: "enabled",
-      }
-    ];
-    it("should return list of phoneNumbers", function(done){
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers?page=1").reply(200, items);
-      PhoneNumber.list(helper.createClient(), {page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of phoneNumbers (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers?page=1").reply(200, items);
-      PhoneNumber.list({page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of phoneNumbers (without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers").reply(200, items);
-      PhoneNumber.list(helper.createClient(),  function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of phoneNumbers (with default client, without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers").reply(200, items);
-      PhoneNumber.list(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should fail if request failed", function(done){
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers").reply(500);
-      PhoneNumber.list(helper.createClient(),  function(err, list){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#get", function(){
-    var item = {
-        id: "1",
-        number: "111111",
-        numberState: "enabled"
-    };
-    it("should return a phoneNumber", function(done){
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(200, item);
-      PhoneNumber.get(helper.createClient(), "1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should return a phoneNumber (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(200, item);
-      PhoneNumber.get("1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(500);
-      PhoneNumber.get(helper.createClient(), "1", function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#create", function(){
-    var item = {
-        id: "1",
-        number: "111111",
-        numberState: "enabled"
-    };
-    var data = {
-        number: "111111"
-    };
-    it("should create a phoneNumber", function(done){
-      helper.nock().post("/v1/users/FakeUserId/phoneNumbers", data).reply(201, "", {"Location": "/v1/users/FakeUserId/phoneNumbers/1"});
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(200, item);
-      PhoneNumber.create(helper.createClient(), data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should create a phoneNumber (with default client)", function(done){
-      helper.nock().post("/v1/users/FakeUserId/phoneNumbers", data).reply(201, "", {"Location": "/v1/users/FakeUserId/phoneNumbers/1"});
-      helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(200, item);
-      PhoneNumber.create(data,  function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().post("/v1/users/FakeUserId/phoneNumbers").reply(500);
-      PhoneNumber.create(helper.createClient(), data, function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#update", function(){
-    it("should update a phoneNumber", function(done){
-      var data = {numberState: "disabled" };
-      helper.nock().post("/v1/users/FakeUserId/phoneNumbers/1", data).reply(200);
-      var phoneNumber = new PhoneNumber();
-      phoneNumber.id = 1;
-      phoneNumber.client = helper.createClient();
-      phoneNumber.update(data, done);
-    });
-  });
+describe("PhoneNumber", function () {
+	before(function () {
+		nock.disableNetConnect();
+		helper.setupGlobalOptions();
+	});
 
-  describe("#delete", function(){
-    it("should delete a phoneNumber", function(done){
-      helper.nock().delete("/v1/users/FakeUserId/phoneNumbers/1").reply(200);
-      var phoneNumber = new PhoneNumber();
-      phoneNumber.id = 1;
-      phoneNumber.client = helper.createClient();
-      phoneNumber.delete(done);
-    });
-  });
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	describe("#list", function () {
+		var items = [ {
+			id          : "1",
+			number      : "111111",
+			numberState : "enabled"
+		}, {
+			id          : "2",
+			number      : "222222",
+			numberState : "enabled"
+		} ];
+
+		it("should return list of phoneNumbers", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/phoneNumbers?page=1").reply(200, items);
+			PhoneNumber.list(helper.createClient(), { page : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return list of phoneNumbers (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/phoneNumbers?page=1").reply(200, items);
+			PhoneNumber.list({ page : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return list of phoneNumbers (without query)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/phoneNumbers").reply(200, items);
+			PhoneNumber.list(helper.createClient(),  function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return list of phoneNumbers (with default client, without query)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/phoneNumbers").reply(200, items);
+			PhoneNumber.list(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should fail if request failed", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/phoneNumbers").reply(500);
+			PhoneNumber.list(helper.createClient(),  function (err, list) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#get", function () {
+		var item = {
+			id          : "1",
+			number      : "111111",
+			numberState : "enabled"
+		};
+		it("should return a phoneNumber", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(200, item);
+			PhoneNumber.get(helper.createClient(), "1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should return a phoneNumber (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(200, item);
+			PhoneNumber.get("1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(500);
+			PhoneNumber.get(helper.createClient(), "1", function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#create", function () {
+		var item = {
+			id          : "1",
+			number      : "111111",
+			numberState : "enabled"
+		};
+
+		var data = {
+			number : "111111"
+		};
+
+		it("should create a phoneNumber", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/phoneNumbers", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/phoneNumbers/1" });
+			helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(200, item);
+			PhoneNumber.create(helper.createClient(), data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should create a phoneNumber (with default client)", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/phoneNumbers", data).reply(201, "",
+				{ "Location" : "/v1/users/FakeUserId/phoneNumbers/1" });
+			helper.nock().get("/v1/users/FakeUserId/phoneNumbers/1").reply(200, item);
+			PhoneNumber.create(data,  function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/phoneNumbers").reply(500);
+			PhoneNumber.create(helper.createClient(), data, function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#update", function () {
+		it("should update a phoneNumber", function (done) {
+			var data = { numberState : "disabled" };
+			helper.nock().post("/v1/users/FakeUserId/phoneNumbers/1", data).reply(200);
+			var phoneNumber = new PhoneNumber();
+			phoneNumber.id = 1;
+			phoneNumber.client = helper.createClient();
+			phoneNumber.update(data, done);
+		});
+	});
+
+	describe("#delete", function () {
+		it("should delete a phoneNumber", function (done) {
+			helper.nock().delete("/v1/users/FakeUserId/phoneNumbers/1").reply(200);
+			var phoneNumber = new PhoneNumber();
+			phoneNumber.id = 1;
+			phoneNumber.client = helper.createClient();
+			phoneNumber.delete(done);
+		});
+	});
 });

--- a/test/recording.js
+++ b/test/recording.js
@@ -1,186 +1,228 @@
 "use strict";
+
 var lib = require("../");
 var helper = require("./helper");
 var nock = require("nock");
 var Recording = lib.Recording;
 
-describe("Recording", function(){
-  before(function(){
-    nock.disableNetConnect();
-    helper.setupGlobalOptions();
-  });
-  after(function(){
-    nock.cleanAll();
-    nock.enableNetConnect();
-  });
-  describe("#list", function(){
-    var items = [{
-        id: "1",
-        call: "call1",
-        media: "media1",
-      },{
-        id: "2",
-        call: "call2",
-        media: "media2",
-      }
-    ];
-    it("should return list of recordings", function(done){
-      helper.nock().get("/v1/users/FakeUserId/recordings?page=1").reply(200, items);
-      Recording.list(helper.createClient(), {page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of recordings (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/recordings?page=1").reply(200, items);
-      Recording.list({page: 1}, function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of recordings (without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/recordings").reply(200, items);
-      Recording.list(helper.createClient(),  function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should return list of recordings (with default client, without query)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/recordings").reply(200, items);
-      Recording.list(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.forEach(function(i){delete i.client;});
-        list.should.eql(items);
-        done();
-      });
-    });
-    it("should fail if request failed", function(done){
-      helper.nock().get("/v1/users/FakeUserId/recordings").reply(500);
-      Recording.list(helper.createClient(),  function(err, list){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#get", function(){
-    var item = {
-        id: "1",
-        call: "call1",
-        media: "media1"
-    };
-    it("should return a recording", function(done){
-      helper.nock().get("/v1/users/FakeUserId/recordings/1").reply(200, item);
-      Recording.get(helper.createClient(), "1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should return a recording (with default client)", function(done){
-      helper.nock().get("/v1/users/FakeUserId/recordings/1").reply(200, item);
-      Recording.get("1", function(err, i){
-        if(err){
-          return done(err);
-        }
-        delete i.client;
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().get("/v1/users/FakeUserId/recordings/1").reply(500);
-      Recording.get(helper.createClient(), "1", function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#createTranscription", function(){
-    it("should create a transcription", function(done){
-      var item = {id: "101"};
-      helper.nock().post("/v1/users/FakeUserId/recordings/1/transcriptions").reply(201, "", {"Location": "/v1/users/FakeUserId/recordings/1/transcriptions/101"});
-      helper.nock().get("/v1/users/FakeUserId/recordings/1/transcriptions/101").reply(200, item);
-      var recording = new Recording();
-      recording.id = 1;
-      recording.client = helper.createClient();
-      recording.createTranscription(function(err, i){
-        if(err){
-          return done(err);
-        }
-        i.should.eql(item);
-        done();
-      });
-    });
-    it("should fail on remote request failing", function(done){
-      helper.nock().post("/v1/users/FakeUserId/recordings/1/transcriptions").reply(500);
-      var recording = new Recording();
-      recording.id = 1;
-      recording.client = helper.createClient();
-      recording.createTranscription(function(err){
-        if(err){
-          return done();
-        }
-        done(new Error("An error is estimated"));
-      });
-    });
-  });
-  describe("#getTranscription", function(){
-    var item = {
-        id: "101"
-    };
-    it("should return a transcription", function(done){
-      helper.nock().get("/v1/users/FakeUserId/recordings/1/transcriptions/101").reply(200, item);
-      var recording = new Recording();
-      recording.id = 1;
-      recording.client = helper.createClient();
-      recording.getTranscription("101", function(err, i){
-        if(err){
-          return done(err);
-        }
-        i.should.eql(item);
-        done();
-      });
-    });
-  });
-  describe("#getTranscriptions", function(){
-    var items = [{
-        id: "101"
-    }, {
-      id: "102"
-    }];
-    it("should return transcriptions", function(done){
-      helper.nock().get("/v1/users/FakeUserId/recordings/1/transcriptions").reply(200, items);
-      var recording = new Recording();
-      recording.id = 1;
-      recording.client = helper.createClient();
-      recording.getTranscriptions(function(err, list){
-        if(err){
-          return done(err);
-        }
-        list.should.eql(items);
-        done();
-      });
-    });
-  });
+describe("Recording", function () {
+	before(function () {
+		nock.disableNetConnect();
+		helper.setupGlobalOptions();
+	});
+
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	describe("#list", function () {
+		var items = [ {
+			id    : "1",
+			call  : "call1",
+			media : "media1"
+		}, {
+			id    : "2",
+			call  : "call2",
+			media : "media2"
+		} ];
+
+		it("should return list of recordings", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/recordings?page=1").reply(200, items);
+			Recording.list(helper.createClient(), { page : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return list of recordings (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/recordings?page=1").reply(200, items);
+			Recording.list({ page : 1 }, function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return list of recordings (without query)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/recordings").reply(200, items);
+			Recording.list(helper.createClient(),  function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should return list of recordings (with default client, without query)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/recordings").reply(200, items);
+			Recording.list(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.forEach(function (i) {
+					delete i.client;
+				});
+
+				list.should.eql(items);
+				done();
+			});
+		});
+
+		it("should fail if request failed", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/recordings").reply(500);
+			Recording.list(helper.createClient(),  function (err, list) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#get", function () {
+		var item = {
+			id    : "1",
+			call  : "call1",
+			media : "media1"
+		};
+
+		it("should return a recording", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/recordings/1").reply(200, item);
+			Recording.get(helper.createClient(), "1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should return a recording (with default client)", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/recordings/1").reply(200, item);
+			Recording.get("1", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				delete i.client;
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/recordings/1").reply(500);
+			Recording.get(helper.createClient(), "1", function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#createTranscription", function () {
+		it("should create a transcription", function (done) {
+			var item = { id : "101" };
+			helper.nock().post("/v1/users/FakeUserId/recordings/1/transcriptions")
+				.reply(201, "", {
+					"Location" : "/v1/users/FakeUserId/recordings/1/transcriptions/101"
+				});
+			helper.nock().get("/v1/users/FakeUserId/recordings/1/transcriptions/101").reply(200, item);
+			var recording = new Recording();
+			recording.id = 1;
+			recording.client = helper.createClient();
+			recording.createTranscription(function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				i.should.eql(item);
+				done();
+			});
+		});
+
+		it("should fail on remote request failing", function (done) {
+			helper.nock().post("/v1/users/FakeUserId/recordings/1/transcriptions").reply(500);
+			var recording = new Recording();
+			recording.id = 1;
+			recording.client = helper.createClient();
+			recording.createTranscription(function (err) {
+				if (err) {
+					return done();
+				}
+
+				done(new Error("An error is estimated"));
+			});
+		});
+	});
+
+	describe("#getTranscription", function () {
+		var item = {
+			id : "101"
+		};
+		it("should return a transcription", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/recordings/1/transcriptions/101").reply(200, item);
+			var recording = new Recording();
+			recording.id = 1;
+			recording.client = helper.createClient();
+			recording.getTranscription("101", function (err, i) {
+				if (err) {
+					return done(err);
+				}
+
+				i.should.eql(item);
+				done();
+			});
+		});
+	});
+
+	describe("#getTranscriptions", function () {
+		var items = [ {
+			id : "101"
+		}, {
+			id : "102"
+		} ];
+		it("should return transcriptions", function (done) {
+			helper.nock().get("/v1/users/FakeUserId/recordings/1/transcriptions").reply(200, items);
+			var recording = new Recording();
+			recording.id = 1;
+			recording.client = helper.createClient();
+			recording.getTranscriptions(function (err, list) {
+				if (err) {
+					return done(err);
+				}
+
+				list.should.eql(items);
+				done();
+			});
+		});
+	});
 });

--- a/test/xml.js
+++ b/test/xml.js
@@ -1,94 +1,116 @@
 "use strict";
+
 var xml = require("../").xml;
 
-function toXml(verb){
-  return new xml.Response([verb]).toXml();
+function toXml(verb) {
+	return new xml.Response([ verb ]).toXml();
 }
 
+describe("Bandwidth XML", function () {
+	describe("Response", function () {
+		it("should generate valid xml", function () {
+			var response = new xml.Response();
+			response.toXml().should.equal("<?xml version=\"1.0\"?>\n<Response/>");
+			response.push(new xml.Hangup());
+			response.toXml().should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Hangup/>\n</Response>");
+			response.push(new xml.Hangup());
+			response.toXml().should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Hangup/>\n  <Hangup/>\n</Response>");
+			response = new xml.Response([ new xml.Hangup(), new xml.Hangup() ]);
+			response.toXml().should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Hangup/>\n  <Hangup/>\n</Response>");
+		});
+	});
 
-describe("Bandwidth XML", function(){
-  describe("Response", function(){
-    it("should generate valid xml", function(){
-      var response = new xml.Response();
-      response.toXml().should.equal("<?xml version=\"1.0\"?>\n<Response/>");
-      response.push(new xml.Hangup());
-      response.toXml().should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Hangup/>\n</Response>");
-      response.push(new xml.Hangup());
-      response.toXml().should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Hangup/>\n  <Hangup/>\n</Response>");
-      response = new xml.Response([new xml.Hangup(), new xml.Hangup()]);
-      response.toXml().should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Hangup/>\n  <Hangup/>\n</Response>");
-    });
-  });
-  describe("Gather", function(){
-    it("should generate valid xml", function(){
-      var gather = new xml.Gather({requestUrl: "http://localhost"});
-      toXml(gather).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Gather requestUrl=\"http://localhost\"/>\n</Response>");
-      gather = new xml.Gather({requestUrl: "http://localhost", maxDigits: 3});
-      toXml(gather).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Gather requestUrl=\"http://localhost\" maxDigits=\"3\"/>\n</Response>");
-    });
-  });
-  describe("Hangup", function(){
-    it("should generate valid xml", function(){
-      var hangup = new xml.Hangup();
-      toXml(hangup).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Hangup/>\n</Response>");
-    });
-  });
-  describe("Pause", function(){
-    it("should generate valid xml", function(){
-      var pause = new xml.Pause({duration: 10});
-      toXml(pause).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Pause duration=\"10\"/>\n</Response>");
-    });
-  });
-  describe("PlayAudio", function(){
-    it("should generate valid xml", function(){
-      var verb = new xml.PlayAudio({url: "http://localhost", digits: "0" });
-      toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <PlayAudio digits=\"0\">http://localhost</PlayAudio>\n</Response>");
-    });
-  });
-  describe("Record", function(){
-    it("should generate valid xml", function(){
-      var verb = new xml.Record({maxDuration: 120 });
-      toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Record maxDuration=\"120\"/>\n</Response>");
-    });
-  });
-  describe("Redirect", function(){
-    it("should generate valid xml", function(){
-      var verb = new xml.Redirect({requestUrl: "http://localhost" });
-      toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Redirect requestUrl=\"http://localhost\"/>\n</Response>");
-    });
-  });
-  describe("Reject", function(){
-    it("should generate valid xml", function(){
-      var verb = new xml.Reject({reason: "error" });
-      toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Reject reason=\"error\"/>\n</Response>");
-    });
-  });
-  describe("SpeakSentence", function(){
-    it("should generate valid xml", function(){
-      var verb = new xml.SpeakSentence({sentence: "Hello", gender: "male", voice: "paul", locale: "en_US" });
-      toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <SpeakSentence voice=\"paul\" locale=\"en_US\" gender=\"male\">Hello</SpeakSentence>\n</Response>");
-    });
-  });
-  describe("SendMessage", function(){
-    it("should generate valid xml", function(){
-      var verb = new xml.SendMessage({from: "from", to: "to", text: "Hello", requestUrl: "http://localhost" });
-      toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <SendMessage from=\"from\" to=\"to\" requestUrl=\"http://localhost\">Hello</SendMessage>\n</Response>");
-    });
-  });
-  describe("Transfer", function(){
-    it("should generate valid xml", function(){
-      var verb = new xml.Transfer({transferTo: "number", transferCallerId: "callerId" });
-      toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Transfer transferTo=\"number\" transferCallerId=\"callerId\"/>\n</Response>");
-      verb.speakSentence = new xml.SpeakSentence({sentence: "Hello"});
-      toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Transfer transferTo=\"number\" transferCallerId=\"callerId\">\n    <SpeakSentence>Hello</SpeakSentence>\n  </Transfer>\n</Response>");
-      verb = new xml.Transfer({
-        transferTo: "number",
-        transferCallerId: "callerId",
-        speakSentence: {
-          sentence: "Hello"
-        }
-      });
-      toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Transfer transferTo=\"number\" transferCallerId=\"callerId\">\n    <SpeakSentence>Hello</SpeakSentence>\n  </Transfer>\n</Response>");
-    });
-  });
+	describe("Gather", function () {
+		it("should generate valid xml", function () {
+			var gather = new xml.Gather({ requestUrl : "http://localhost" });
+			toXml(gather).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  " +
+				"<Gather requestUrl=\"http://localhost\"/>\n</Response>");
+			gather = new xml.Gather({ requestUrl : "http://localhost", maxDigits : 3 });
+			toXml(gather).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  " +
+				"<Gather requestUrl=\"http://localhost\" maxDigits=\"3\"/>\n</Response>");
+		});
+	});
+
+	describe("Hangup", function () {
+		it("should generate valid xml", function () {
+			var hangup = new xml.Hangup();
+			toXml(hangup).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Hangup/>\n</Response>");
+		});
+	});
+
+	describe("Pause", function () {
+		it("should generate valid xml", function () {
+			var pause = new xml.Pause({ duration : 10 });
+			toXml(pause).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Pause duration=\"10\"/>\n</Response>");
+		});
+	});
+
+	describe("PlayAudio", function () {
+		it("should generate valid xml", function () {
+			var verb = new xml.PlayAudio({ url : "http://localhost", digits : "0" });
+			toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  " +
+				"<PlayAudio digits=\"0\">http://localhost</PlayAudio>\n</Response>");
+		});
+	});
+
+	describe("Record", function () {
+		it("should generate valid xml", function () {
+			var verb = new xml.Record({ maxDuration : 120 });
+			toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Record maxDuration=\"120\"/>\n</Response>");
+		});
+	});
+
+	describe("Redirect", function () {
+		it("should generate valid xml", function () {
+			var verb = new xml.Redirect({ requestUrl : "http://localhost" });
+			toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  " +
+				"<Redirect requestUrl=\"http://localhost\"/>\n</Response>");
+		});
+	});
+
+	describe("Reject", function () {
+		it("should generate valid xml", function () {
+			var verb = new xml.Reject({ reason : "error" });
+			toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  <Reject reason=\"error\"/>\n</Response>");
+		});
+	});
+
+	describe("SpeakSentence", function () {
+		it("should generate valid xml", function () {
+			var verb = new xml.SpeakSentence({ sentence : "Hello", gender : "male", voice : "paul", locale : "en_US" });
+			toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  " +
+			"<SpeakSentence voice=\"paul\" locale=\"en_US\" gender=\"male\">Hello</SpeakSentence>\n</Response>");
+		});
+	});
+
+	describe("SendMessage", function () {
+		it("should generate valid xml", function () {
+			var verb = new xml.SendMessage({ from : "from", to : "to", text : "Hello", requestUrl : "http://localhost" });
+			toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  " +
+			"<SendMessage from=\"from\" to=\"to\" requestUrl=\"http://localhost\">Hello</SendMessage>\n</Response>");
+		});
+	});
+
+	describe("Transfer", function () {
+		it("should generate valid xml", function () {
+			var verb = new xml.Transfer({ transferTo : "number", transferCallerId : "callerId" });
+			toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  " +
+			"<Transfer transferTo=\"number\" transferCallerId=\"callerId\"/>\n</Response>");
+			verb.speakSentence = new xml.SpeakSentence({ sentence : "Hello" });
+			toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  " +
+			"<Transfer transferTo=\"number\" transferCallerId=\"callerId\">\n    " +
+				"<SpeakSentence>Hello</SpeakSentence>\n  </Transfer>\n</Response>");
+			verb = new xml.Transfer({
+				transferTo       : "number",
+				transferCallerId : "callerId",
+				speakSentence    : {
+					sentence : "Hello"
+				}
+			});
+
+			toXml(verb).should.equal("<?xml version=\"1.0\"?>\n<Response>\n  " +
+			"<Transfer transferTo=\"number\" transferCallerId=\"callerId\">\n    " +
+				"<SpeakSentence>Hello</SpeakSentence>\n  </Transfer>\n</Response>");
+		});
+	});
 });


### PR DESCRIPTION
This pull request includes Gulp and enforces Bandwidth's style guidelines for JavaScript using JSHint and JSCS. This PR will resolve https://github.com/bandwidthcom/node-bandwidth/issues/18

I changed a few of the style and hint rules as detailed here:
- Removed `disallowQuotedKeysInObjects`
  - This is required by this specific project for setting some field names that are not valid JavaScript variable names, such as certain HTTP headers
- Changed maximum argument count to 5
- Removed rule to disallow `++`

Because the code coverage threshold is set to 100% Gulp will fail the build until we increase test coverage.

For code review, the first commit in this PR contains all the important changes, including the gulpfile and style rules. The second commit simply updates all the code files to follow those rules.
