### PR TITLE
Cancel portin

### DIFF
--- a/lib/compatibility.js
+++ b/lib/compatibility.js
@@ -33,7 +33,6 @@ module.exports = function (lib) {
 		getApplications         : "Application.list()",
 		portIn                  : "Iris API",
 		uploadLOA               : "Iris API",
-		cancelPortIn            : "Iris API",
 		getPortInState          : "Iris API",
 		checkPortInAvailability : "Iris API"
 	};
@@ -152,10 +151,6 @@ module.exports = function (lib) {
 		},
 
 		uploadLOA : function (portInId, filePath, callback) {
-			callback(new Error("Not supported"));
-		},
-
-		cancelPortIn : function (portInId, callback) {
 			callback(new Error("Not supported"));
 		},
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ module.exports = {
 	PhoneNumber      : require("./phoneNumber"),
 	Recording        : require("./recording"),
 	xml              : require("./xml"),
+	PortIns          : require("./portIns"),
 	errors           : require("./errors")
 };
 

--- a/lib/portIns.js
+++ b/lib/portIns.js
@@ -1,0 +1,19 @@
+"use strict";
+
+var Client = require("./client");
+var PORTIN_PATH = "portIns";
+
+module.exports = {
+
+	cancel : function (client, portInsId, callback) {
+		if (arguments.length === 2) {
+			callback = portInsId;
+			portInsId = client;
+			client = new Client();
+		}
+		var data = {
+			state : "cancelled"
+		};
+		client.makeRequest("post", client.concatUserPath(PORTIN_PATH) + "/" + portInsId, data, callback);
+	}
+};

--- a/lib/portIns.js
+++ b/lib/portIns.js
@@ -5,6 +5,14 @@ var PORTIN_PATH = "portIns";
 
 module.exports = {
 
+	/**
+	 * Cancels a portin based on portInsID
+	 * @param client Client instance
+ 	 * @param portInsId Id of portIn
+ 	 * @param callback callback function
+ 	 * @example
+ 	 * bandwidth.PortIns.cancel(client, "portInsId", function(err, number){});
+	 */
 	cancel : function (client, portInsId, callback) {
 		if (arguments.length === 2) {
 			callback = portInsId;

--- a/test/compatibility.js
+++ b/test/compatibility.js
@@ -413,18 +413,6 @@ describe("Client compatibility functions", function () {
 		});
 	});
 
-	describe("#cancelPortIn", function () {
-		it("should throw an error", function (done) {
-			client.cancelPortIn("id", function (err) {
-				if (err) {
-					return done();
-				}
-
-				done("An error is expected");
-			});
-		});
-	});
-
 	describe("#uploadLOA", function () {
 		it("should throw an error", function (done) {
 			client.uploadLOA("id", "file", function (err) {

--- a/test/portIns.js
+++ b/test/portIns.js
@@ -1,0 +1,111 @@
+"use strict";
+
+var lib = require("../");
+var helper = require("./helper");
+var nock = require("nock");
+var PortIns = lib.PortIns;
+
+describe("PortIns", function () {
+	before(function () {
+		nock.disableNetConnect();
+		helper.setupGlobalOptions();
+	});
+
+	after(function () {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+	var PORTIN_PATH = "/v1/users/FakeUserId/portIns/";
+	describe("#cancel", function () {
+		var portInsId = "lnpin-abc123";
+		var cancelBody = { state : "cancelled" };
+		var errorResponse = { "message" : "The order is already cancelled and cannot be modified or cancelled" };
+		describe("When Client is supplied", function () {
+			var client = helper.createClient();
+			describe("and the port in can be cancelled", function () {
+				var result;
+				var error;
+				before(function () {
+					helper.nock()
+						.post(PORTIN_PATH + portInsId, cancelBody)
+						.reply(200, "OK");
+					PortIns.cancel(client, portInsId, function (err, res) {
+						error = err;
+						result = res;
+					});
+				});
+				it("should callback with an empty object", function () {
+					result.should.eql({});
+				});
+				it("should not callback with an error", function () {
+					var isNull = error === null;
+					isNull.should.be.true;
+				});
+
+			});
+			describe("and the port in can not be cancelled", function () {
+				var result;
+				var error;
+				before(function () {
+					helper.nock()
+						.post(PORTIN_PATH + portInsId, cancelBody)
+						.reply(503, errorResponse);
+					PortIns.cancel(client, portInsId, function (err, res) {
+						error = err;
+						result = res;
+					});
+				});
+				it("should callback with an error", function () {
+					error.message.should.eql(errorResponse.message);
+				});
+				it("should not callback with a result", function () {
+					var isUndefined = typeof result === "undefined";
+					isUndefined.should.be.true;
+				});
+			});
+		});
+		describe("When using default client", function () {
+			describe("and the port in can be cancelled", function () {
+				var result;
+				var error;
+				before(function () {
+					helper.nock()
+						.post(PORTIN_PATH + portInsId, cancelBody)
+						.reply(200, "OK");
+					PortIns.cancel(portInsId, function (err, res) {
+						error = err;
+						result = res;
+					});
+				});
+				it("should callback with an empty object", function () {
+					result.should.eql({});
+				});
+				it("should not callback with an error", function () {
+					var isNull = error === null;
+					isNull.should.be.true;
+				});
+
+			});
+			describe("and the port in can not be cancelled", function () {
+				var result;
+				var error;
+				before(function () {
+					helper.nock()
+						.post(PORTIN_PATH + portInsId, cancelBody)
+						.reply(503, errorResponse);
+					PortIns.cancel(portInsId, function (err, res) {
+						error = err;
+						result = res;
+					});
+				});
+				it("should callback with an error", function () {
+					error.message.should.eql(errorResponse.message);
+				});
+				it("should not callback with a result", function () {
+					var isUndefined = typeof result === "undefined";
+					isUndefined.should.be.true;
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
Adds the lib/portIns.js file with first function 'cancel'

Cancel takes 
- client object (if not supplied will use the default client) - the Bandwidth Application Platform Client
- portInsId - ID of the portIn to be cancelled
- callback - callback function

If the port in does not exist or can not be cancelled, the function will callback with an error propagating the error message returned from the Bandwidth Application Platform.

Adds the test/portIns.js file for cancel. 
Tests cover the basic functionality described above
