### PR TITLE
Adds the ability to update an endpoint through the domain object

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -202,4 +202,20 @@ Domain.prototype.deleteEndPoint = function (endpointId, callback) {
 	item.delete(callback);
 };
 
+/**
+ * Update an endpoint
+ * @param endpointId Id of endpoint to remove
+ * @param data JSON Object with new values
+ * @param callback callback
+ * @example
+ * domain.updateEndPoint("id", {enabled: "false"}, function(err){});
+ */
+Domain.prototype.updateEndPoint = function (endpointId, data, callback) {
+	var item = new EndPoint();
+	item.client = this.client;
+	item.id = endpointId;
+	item.domainId = this.id;
+	item.update(data, callback);
+};
+
 module.exports = Domain;

--- a/lib/endPoint.js
+++ b/lib/endPoint.js
@@ -38,4 +38,17 @@ EndPoint.prototype.createAuthToken = function (callback) {
 	});
 };
 
+/**
+ * Update endpoint with data
+ * @param data JSON Object with new values
+ * @param callback callback
+ * @example
+ * endPoint.update({enabled: "false"}, function(err, res){})
+ */
+EndPoint.prototype.update = function (data, callback) {
+	var self = this;
+	var path =  self.client.concatUserPath(DOMAIN_PATH) + "/" + self.domainId + "/" + ENDPOINT_PATH + "/" + self.id;
+	self.client.makeRequest("post", path, data, callback);
+};
+
 module.exports = EndPoint;

--- a/test/domain.js
+++ b/test/domain.js
@@ -364,4 +364,60 @@ describe("Domain", function () {
 			domain.deleteEndPoint("10", done);
 		});
 	});
+
+	describe("#updateEndPoint", function () {
+		var DOMAIN_PATH = "/v1/users/FakeUserId/domains/";
+		var domain;
+		var domainId = "rd-lrz25ny";
+		var endpointId = "re-kx2kk";
+		var ENDPOINT_PATH = DOMAIN_PATH + domainId + "/endpoints/" + endpointId;
+		var updateBody = { enabled : "false" };
+		var errorResponse = { message : "There are lots of potential errors" };
+		before(function () {
+			domain = new Domain();
+			domain.id = domainId;
+			domain.client = helper.createClient();
+		});
+		describe("When endpoint is updated successfully", function () {
+			var error;
+			var result;
+			before(function () {
+				helper.nock()
+					.post(ENDPOINT_PATH, updateBody)
+					.reply(200, "OK");
+				domain.updateEndPoint(endpointId, updateBody, function (err, res) {
+					error = err;
+					result = res;
+				});
+			});
+			it("should callback with an empty object", function () {
+				result.should.eql({});
+			});
+			it("should not callback with an error", function () {
+				var isNull = error === null;
+				isNull.should.be.true;
+			});
+		});
+		describe("When enpoint is not updated successfully", function () {
+			var error;
+			var result;
+			before(function () {
+				helper.nock()
+					.post(ENDPOINT_PATH, updateBody)
+					.reply(400, errorResponse);
+				domain.updateEndPoint(endpointId, updateBody, function (err, res) {
+					error = err;
+					result = res;
+				});
+			});
+			it("should callback with an error", function () {
+				error.message.should.eql(errorResponse.message);
+			});
+			it("should not callback with a result", function () {
+				var isUndefined = typeof result === "undefined";
+				isUndefined.should.be.true;
+			});
+		});
+
+	});
 });

--- a/test/endPoint.js
+++ b/test/endPoint.js
@@ -6,6 +6,7 @@ var nock = require("nock");
 var EndPoint = lib.EndPoint;
 
 describe("EndPoint", function () {
+	var DOMAIN_PATH = "/v1/users/FakeUserId/domains/";
 
 	before(function () {
 		nock.disableNetConnect();
@@ -56,6 +57,66 @@ describe("EndPoint", function () {
 			endPoint.createAuthToken(function (err, data) {
 				err.should.not.eql(null);
 				done();
+			});
+		});
+	});
+
+	describe("#update", function () {
+		var endPoint;
+		var domainId = "rd-lrz25ny";
+		var endpointId = "re-kx2kk";
+		var ENDPOINT_PATH = DOMAIN_PATH + domainId + "/endpoints/" + endpointId;
+		var updateBody = { enabled : "false" };
+		var errorResponse = { message : "There are lots of potential errors" };
+		before(function () {
+			endPoint = new EndPoint();
+			endPoint.domainId = domainId;
+			endPoint.id = endpointId;
+			endPoint.client = helper.createClient();
+		});
+
+		describe("When endpoint is updated successfully", function () {
+			var result;
+			var error;
+
+			before(function () {
+				helper.nock()
+					.post(ENDPOINT_PATH, updateBody)
+					.reply(200, "OK");
+				endPoint.update(updateBody, function (err, res) {
+					error = err;
+					result = res;
+				});
+			});
+
+			it("should callback with an empty object", function () {
+				result.should.eql({});
+			});
+			it("should not callback with an error", function () {
+				var isNull = error === null;
+				isNull.should.be.true;
+			});
+
+		});
+		describe("When enpoint is not update successfully", function () {
+			var result;
+			var error;
+
+			before(function () {
+				helper.nock()
+					.post(ENDPOINT_PATH, updateBody)
+					.reply(400, errorResponse);
+				endPoint.update(updateBody, function (err, res) {
+					error = err;
+					result = res;
+				});
+			});
+			it("should callback with an error", function () {
+				error.message.should.eql(errorResponse.message);
+			});
+			it("should not callback with a result", function () {
+				var isUndefined = typeof result === "undefined";
+				isUndefined.should.be.true;
 			});
 		});
 	});


### PR DESCRIPTION
Adds the endpoint.update method which accepts:
- Updated JSON `all keys are optional, but the json object is required`: 

``` json
{
        "name" : "jsmith_mobile", 
        "description" : "John Smiths mobile client", 
        "application_id" : "{application-id}", 
        "enabled" : "false",
        "credentials" : { "password" : "abc123" } 
}
```
- Callback

Adds the domain.updateEndPoint which accepts:
- endpoint ID 
- Updated JSON 'see above'
- callback

Adds the tests for both positive and negative response from bandwidth application platform
