### PR TITLE
Use "request" instead of superagent for downloading media

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -58,7 +58,7 @@ function Client(userId, apiToken, apiSecret, options) {
 	this.prepareUrl = function (path) {
 		return options.apiEndPoint + "/" + options.apiVersion + ((path[0] === "/") ? path : ("/" + path));
 	};
-	this.rawGetRequest = function (uri, callback) {
+	this.rawGetRequest = function (uri) {
 		return request({
 			url  : this.prepareUrl(uri),
 			auth : {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,6 @@
 var superagent = require("superagent");
 var errors = require("./errors");
+var request = require("request");
 
 /** Constructor */
 function Client(userId, apiToken, apiSecret, options) {
@@ -57,6 +58,16 @@ function Client(userId, apiToken, apiSecret, options) {
 	this.prepareUrl = function (path) {
 		return options.apiEndPoint + "/" + options.apiVersion + ((path[0] === "/") ? path : ("/" + path));
 	};
+	this.rawGetRequest = function (uri, callback) {
+		return request({
+			url  : this.prepareUrl(uri),
+			auth : {
+				user : apiToken,
+				pass : apiSecret
+			}
+		});
+	};
+
 }
 
 /** global options (used when constructor called without params) */

--- a/lib/media.js
+++ b/lib/media.js
@@ -192,27 +192,23 @@ module.exports = {
 			name = client;
 			client = new Client();
 		}
-
-		var request = client.createRequest("get", client.concatUserPath(MEDIA_PATH) + "/" + encodeURIComponent(name));
-
-		request.end(function (err, res) {
-			// Receive chunks of data into an array of Buffers
+		var path = client.concatUserPath(MEDIA_PATH) + "/" + encodeURIComponent(name);
+		client.rawGetRequest(path)
+		.on("error", function (err) {
+			callback(err, null);
+		})
+		.on("response", function (res) {
 			var buf = [];
 			res.on("data", function (chunk) {
 				buf.push(chunk);
 			});
-			// Response end
 			res.on("end", function () {
-				if (res.ok) {
-					return callback(null,
-						{
-							contentType   : res.type,
-							contentLength : res.header["content-length"],
-							contentBody   : Buffer.concat(buf)
-						});
-				}
-				// Not OK
-				return callback(new errors.BandwidthError("Http code " + res.status, res.status));
+				var data = Buffer.concat(buf);
+				callback(null, {
+					contentType   : res.headers["content-type"].split(";")[0],
+					contentLength : data.length,
+					contentBody   : data
+				});
 			});
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/bandwidthcom/node-bandwidth",
   "dependencies": {
+    "request": "^2.61.0",
     "superagent": "^0.21.0",
     "xmlbuilder": "2.4.3"
   },

--- a/test/media.js
+++ b/test/media.js
@@ -123,38 +123,45 @@ describe("Media", function () {
 		it("should get contents for a file from server", function (done) {
 			var contents = "somecontents";
 			var length = contents.length;
-			helper.nock().get("/v1/users/FakeUserId/media/file1").reply(200, contents, { "Content-Length" : length });
+			helper.nock().get("/v1/users/FakeUserId/media/file1").reply(200, contents, {
+				"Content-Type" : "text/plain"
+			});
 			Media.getContents(helper.createClient(), "file1", function (err, result) {
 				if (err) {
 					return done(err);
 				}
 
 				result.contentLength.should.eql(length);
+				result.contentType.should.eql("text/plain");
 				result.contentBody.should.eql(new Buffer(contents));
 				done();
 			});
 		});
-
 		it("should get contents for a file from server (with default client)", function (done) {
 			var contents = "somecontents";
 			var length = contents.length;
-			helper.nock().get("/v1/users/FakeUserId/media/file1").reply(200, contents, { "Content-Length" : length });
+			helper.nock().get("/v1/users/FakeUserId/media/file1").reply(200, contents, { "Content-Type" : "text/plain" });
 			Media.getContents("file1", function (err, result) {
 				if (err) {
 					return done(err);
 				}
 
 				result.contentLength.should.eql(length);
+				result.contentType.should.eql("text/plain");
 				result.contentBody.should.eql(new Buffer(contents));
 				done();
 			});
 		});
-
-		it("should error on getting contents on non existing file", function (done) {
-			helper.nock().get("/v1/users/FakeUserId/media/nonexistingfile").reply(404);
-			Media.getContents("nonexistingfile", function (err, result) {
-				err.httpStatus.should.eql(404);
-				done();
+		it("should get return error if there is an error", function (done) {
+			var contents = "somecontents";
+			var length = contents.length;
+			Media.getContents("file1", function (err, result) {
+				if (err) {
+					return done();
+				}
+				else {
+					return done(new Error("should have returned an error"));
+				}
 			});
 		});
 	});


### PR DESCRIPTION
the current Media.getContents function is broken for any content-type that superagent tries to buffer or parse. This PR uses the package "request" instead which simply streams raw data.
