### PR TITLE
Updating tests to use deep equality and to return Promises

### DIFF
--- a/test/call-test.js
+++ b/test/call-test.js
@@ -168,7 +168,7 @@ describe("Call API", function () {
 		it("should get a call, promise style", function () {
 			return client.Call.get(testCall.id)
 			.then(function (call) {
-				call.should.eql(testCall)
+				call.should.eql(testCall);
 			});
 		});
 

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -128,34 +128,31 @@ describe("Call API", function () {
 			nock.enableNetConnect();
 		});
 
-		it("should create a call, promise style", function (done) {
-			client.Call.create(newTestCall)
+		it("should create a call, promise style", function () {
+			return client.Call.create(newTestCall)
 			.then(function (call) {
-				call.to.should.equal(newTestCall.to);
-				call.from.should.equal(newTestCall.from);
-				call.id.should.equal("fakeCallId");
-			})
-			.done(done);
+				call.should.eql(newTestCall);
+			});
 		});
 
-		it("should answer a call", function (done) {
-			client.Call.answer(testCall.id).done(done);
+		it("should answer a call", function () {
+			return client.Call.answer(testCall.id);
 		});
 
-		it("should speak a sentence on a call", function (done) {
-			client.Call.speakSentence(testCall.id, sampleSentence).done(done);
+		it("should speak a sentence on a call", function () {
+			return client.Call.speakSentence(testCall.id, sampleSentence);
 		});
 
-		it("should play an audio file on sentence on a call", function (done) {
-			client.Call.playAudio(testCall.id, audioUrl).done(done);
+		it("should play an audio file on sentence on a call", function () {
+			return client.Call.playAudio(testCall.id, audioUrl);
 		});
 
-		it("should enable recording on a call", function (done) {
-			client.Call.enableRecording(testCall.id).done(done);
+		it("should enable recording on a call", function () {
+			return client.Call.enableRecording(testCall.id);
 		});
 
-		it("should set the maximum recording duration on a call", function (done) {
-			client.Call.setMaxRecordingDuration(testCall.id, maxRecordingDuration).done(done);
+		it("should set the maximum recording duration on a call", function () {
+			return client.Call.setMaxRecordingDuration(testCall.id, maxRecordingDuration);
 		});
 
 		it("should create a call, callback style", function (done) {
@@ -163,38 +160,27 @@ describe("Call API", function () {
 				if (err) {
 					throw err;
 				}
-				call.to.should.equal(newTestCall.to);
-				call.from.should.equal(newTestCall.from);
-				call.id.should.equal("fakeCallId");
+				call.should.eql(newTestCall);
 				done();
 			});
 		});
 
-		it("should get a call, promise style", function (done) {
-			client.Call.get(testCall.id)
+		it("should get a call, promise style", function () {
+			return client.Call.get(testCall.id)
 			.then(function (call) {
-				call.to.should.equal(testCall.to);
-				call.from.should.equal(testCall.from);
-				call.id.should.equal(testCall.id);
-			})
-			.done(done);
+				call.should.eql(testCall)
+			});
 		});
 
-		it("should get a list of calls, promise style", function (done) {
-			client.Call.list({
+		it("should get a list of calls, promise style", function () {
+			return client.Call.list({
 				fromDateTime : fromDateTime,
 				toDateTime   : toDateTime
 			})
 			.then(function (calls) {
-				calls[0].to.should.equal(callsList[0].to);
-				calls[0].from.should.equal(callsList[0].from);
-				calls[0].id.should.equal(callsList[0].id);
-
-				calls[1].to.should.equal(callsList[1].to);
-				calls[1].from.should.equal(callsList[1].from);
-				calls[1].id.should.equal(callsList[1].id);
-			})
-			.done(done);
+				calls[0].should.eql(callsList[0]);
+				calls[1].should.eql(callsList[1]);
+			});
 		});
 
 		it("should get a list of calls, callback style", function (done) {
@@ -205,13 +191,8 @@ describe("Call API", function () {
 				if (err) {
 					throw err;
 				}
-				calls[0].to.should.equal(callsList[0].to);
-				calls[0].from.should.equal(callsList[0].from);
-				calls[0].id.should.equal(callsList[0].id);
-
-				calls[1].to.should.equal(callsList[1].to);
-				calls[1].from.should.equal(callsList[1].from);
-				calls[1].id.should.equal(callsList[1].id);
+				calls[0].should.eql(callsList[0]);
+				calls[1].should.eql(callsList[1]);
 				done();
 			});
 		});

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -111,7 +111,7 @@ describe("Client", function () {
 			return client.makeRequest({
 				path : "account"
 			}).then(function (res) {
-				done("It should have thrown an exception!");
+				throw new Error("It should have thrown an exception!");
 			}).catch(function (err) {
 				err.statusCode.should.equal(401);
 				err.message.should.equal("Something bad happened...");
@@ -122,7 +122,7 @@ describe("Client", function () {
 			return client.makeRequest({
 				path : "unknown"
 			}).then(function (res) {
-				done("It should have thrown an exception!");
+				throw new Error("It should have thrown an exception!");
 			}).catch(function (err) {
 				err.statusCode.should.equal(404);
 				err.message.should.equal("");
@@ -133,7 +133,7 @@ describe("Client", function () {
 			return client.makeRequest({
 				path : "unknown2"
 			}).then(function (res) {
-				done("It should have thrown an exception!");
+				throw new Error("It should have thrown an exception!");
 			}).catch(function (err) {
 				err.statusCode.should.equal(404);
 				err.message.should.equal("");

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -38,14 +38,11 @@ describe("Client", function () {
 			nock.cleanAll();
 		});
 
-		it("should make requests to the default baseUrl", function (done) {
-			client.makeRequest({
+		it("should make requests to the default baseUrl", function () {
+			return client.makeRequest({
 				path : "account"
 			}).then(function (res) {
 				res.body.should.eql(accountResponse);
-				done();
-			}).catch(function (err) {
-				done(err);
 			});
 		});
 	});
@@ -70,18 +67,18 @@ describe("Client", function () {
 			baseUrl = oldBaseUrl;
 		});
 
-		it("should make requests to the custom baseUrl", function (done) {
+		it("should make requests to the custom baseUrl", function () {
 			var accountResponse = {
 				balance     : "20.00",
 				accountType : "pre-pay"
 			};
 
 			nock(baseUrl).get("/v1/users/fakeUserId/account").reply(200, accountResponse);
-			client.makeRequest({
+			return client.makeRequest({
 				path : "account"
 			}).then(function (res) {
 				res.body.should.eql(accountResponse);
-			}).done(done);
+			});
 		});
 
 	});
@@ -110,39 +107,36 @@ describe("Client", function () {
 			nock.cleanAll();
 		});
 
-		it("should throw exceptions on unexpected HTTP responses", function (done) {
-			client.makeRequest({
+		it("should throw exceptions on unexpected HTTP responses", function () {
+			return client.makeRequest({
 				path : "account"
 			}).then(function (res) {
 				done("It should have thrown an exception!");
 			}).catch(function (err) {
 				err.statusCode.should.equal(401);
 				err.message.should.equal("Something bad happened...");
-				done();
 			});
 		});
 
-		it("should throw exceptions on unexpected HTTP responses with no response body", function (done) {
-			client.makeRequest({
+		it("should throw exceptions on unexpected HTTP responses with no response body", function () {
+			return client.makeRequest({
 				path : "unknown"
 			}).then(function (res) {
 				done("It should have thrown an exception!");
 			}).catch(function (err) {
 				err.statusCode.should.equal(404);
 				err.message.should.equal("");
-				done();
 			});
 		});
 
-		it("should throw exceptions on unexpected HTTP responses with an empty response body", function (done) {
-			client.makeRequest({
+		it("should throw exceptions on unexpected HTTP responses with an empty response body", function () {
+			return client.makeRequest({
 				path : "unknown2"
 			}).then(function (res) {
 				done("It should have thrown an exception!");
 			}).catch(function (err) {
 				err.statusCode.should.equal(404);
 				err.message.should.equal("");
-				done();
 			});
 		});
 	});

--- a/test/message-test.js
+++ b/test/message-test.js
@@ -104,10 +104,8 @@ describe("Message API", function () {
 				toDateTime   : toDateTime
 			})
 			.then(function (messageResponse) {
-
 				var messages = messageResponse.messages;
-				messages[0].should.eql(messagesList[0]);
-				messages[1].should.eql(messagesList[1]);
+				messages.should.eql(messagesList);
 			});
 		});
 
@@ -119,10 +117,8 @@ describe("Message API", function () {
 				if (err) {
 					throw err;
 				}
-
 				var messages = messageResponse.messages;
-				messages[0].should.eql(messagesList[0]);
-				messages[1].should.eql(messagesList[1]);
+				messages.should.eql(messagesList);
 				done();
 			});
 		});

--- a/test/recording-test.js
+++ b/test/recording-test.js
@@ -67,31 +67,18 @@ describe("Recording API", function () {
 			nock.enableNetConnect();
 		});
 
-		it("should get a recording", function (done) {
-			client.Recording.get(testRecording.id)
+		it("should get a recording", function () {
+			return client.Recording.get(testRecording.id)
 			.then(function (recording) {
-				recording.id.should.equal(testRecording.id);
-				recording.media.should.equal(testRecording.media);
-				recording.startTime.should.equal(testRecording.startTime);
-				recording.endTime.should.equal(testRecording.endTime);
-			})
-			.done(done);
+				recording.should.eql(testRecording);
+			});
 		});
 
-		it("should get a list of messages, promise style", function (done) {
-			client.Recording.list()
+		it("should get a list of messages, promise style", function () {
+			return client.Recording.list()
 			.then(function (recordings) {
-				recordings[0].id.should.equal(recordingList[0].id);
-				recordings[0].media.should.equal(recordingList[0].media);
-				recordings[0].startTime.should.equal(recordingList[0].startTime);
-				recordings[0].endTime.should.equal(recordingList[0].endTime);
-
-				recordings[1].id.should.equal(recordingList[1].id);
-				recordings[1].media.should.equal(recordingList[1].media);
-				recordings[1].startTime.should.equal(recordingList[1].startTime);
-				recordings[1].endTime.should.equal(recordingList[1].endTime);
-			})
-			.done(done);
+				recordings.should.eql(recordingList);
+			});
 		});
 
 	});


### PR DESCRIPTION
Currently, we have many tests that test some promised function and use those promises' `.done` function to call the Mocha `done` callback. Mocha supports ending async tests if a promise is returned; this is the same behavior as we get now. However, native promises do not support `done`; it's better practice to just return the promise.
Further, I switched to deep equality where necessary. This way, we won't have to change the tests if our object schemas change, or if we're mangling one of the attributes we weren't specifically comparing in the old tests.

Feedback is always appreciated!
