### PR TITLE
Rewrite message listing function and headers parsing library

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -18,7 +18,7 @@
   "strict"        : false,
   "trailing"      : true,
   "maxparams"     : 5,
-  "maxdepth"      : 3,
+  "maxdepth"      : 4,
   "maxstatements" : false,
   "maxlen"        : 120,
 

--- a/.jshintrc
+++ b/.jshintrc
@@ -18,7 +18,7 @@
   "strict"        : false,
   "trailing"      : true,
   "maxparams"     : 5,
-  "maxdepth"      : 4,
+  "maxdepth"      : 3,
   "maxstatements" : false,
   "maxlen"        : 120,
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,8 @@
 <dd></dd>
 <dt><a href="#Message">Message</a></dt>
 <dd></dd>
+<dt><a href="#MessageResponse">MessageResponse</a> : <code>Object</code></dt>
+<dd></dd>
 <dt><a href="#Recording">Recording</a></dt>
 <dd></dd>
 </dl>
@@ -288,8 +290,8 @@ Catapult API Client
 
 * [Message](#Message)
     * [new Message(client)](#new_Message_new)
-    * [.send(params, The, The, [callback])](#Message+send) ⇒ <code>MessageResponse</code>
-    * [.get(messageId, [callback])](#Message+get) ⇒ <code>MessageResponse</code>
+    * [.send(params, The, The, [callback])](#Message+send) ⇒ <code>[MessageResponse](#MessageResponse)</code>
+    * [.get(messageId, [callback])](#Message+get) ⇒ <code>[MessageResponse](#MessageResponse)</code>
     * [.list(params, [callback])](#Message+list) ⇒ <code>Array</code>
 
 <a name="new_Message_new"></a>
@@ -304,11 +306,11 @@ SMS or MMS Message
 
 <a name="Message+send"></a>
 
-### message.send(params, The, The, [callback]) ⇒ <code>MessageResponse</code>
+### message.send(params, The, The, [callback]) ⇒ <code>[MessageResponse](#MessageResponse)</code>
 Send a new SMS or MMS message
 
 **Kind**: instance method of <code>[Message](#Message)</code>  
-**Returns**: <code>MessageResponse</code> - A promise for the new message object  
+**Returns**: <code>[MessageResponse](#MessageResponse)</code> - A promise for the new message object  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -326,11 +328,11 @@ Send a new SMS or MMS message
 
 <a name="Message+get"></a>
 
-### message.get(messageId, [callback]) ⇒ <code>MessageResponse</code>
+### message.get(messageId, [callback]) ⇒ <code>[MessageResponse](#MessageResponse)</code>
 Get a message
 
 **Kind**: instance method of <code>[Message](#Message)</code>  
-**Returns**: <code>MessageResponse</code> - A promise for the message  
+**Returns**: <code>[MessageResponse](#MessageResponse)</code> - A promise for the message  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -348,7 +350,42 @@ Gets a list of messages
 | Param | Type | Description |
 | --- | --- | --- |
 | params | <code>Object</code> | Search parameters |
+| [params.from] | <code>String</code> | The phone number to filter the messages that came from (must be in E.164 format, like +19195551212). |
+| [params.to] | <code>String</code> | The phone number to filter the messages that was sent to (must be in E.164 format, like +19195551212). |
+| [params.fromDateTime] | <code>String</code> | The starting date time to filter the messages (must be in yyyy-MM-dd hh:mm:ss format, like 2014-05-25 12:00:00. You can suppress parts of the date or time, like 2014-05-25, but the missing parameters will be filled with zeros). |
+| [params.toDateTime] | <code>String</code> | The ending date time to filter the messages (must be in yyyy-MM-dd hh:mm:ss format, like 2014-05-25 12:00:00. You can suppress parts of the date or time, like 2014-05-25, but the missing parameters will be filled with zeros) |
+| [params.size] | <code>Number</code> | Used for pagination to indicate the size of each page requested \ for querying a list of messages. If no value is specified the default value is 25. (Maximum value 1000) |
+| [params.direction] | <code>String</code> | Filter by direction of message, in - a message that came from the telephone network to one of your numbers (an "inbound" message) or out - a message that was sent from one of your numbers to the telephone network (an "outbound" message) |
+| [params.state] | <code>String</code> | The message state to filter. Values are: received, queued, sending, sent, error |
+| [params.deliveryState] | <code>String</code> | The message delivery state to filter. Values are waiting, delivered, not-delivered |
+| [params.sortOrder] | <code>String</code> | How to sort the messages. Values are asc or desc If no value is specified the default value is asc |
 | [callback] | <code>function</code> | A callback for the list of messages |
+
+<a name="MessageResponse"></a>
+
+## MessageResponse : <code>Object</code>
+**Kind**: global class  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| id | <code>String</code> | The unique ID of the message. |
+| from | <code>String</code> | The message sender's telephone number (or short code). |
+| to | <code>String</code> | Message recipient telephone number (or short code). |
+| direction | <code>String</code> | Direction of message, in - a message that came from the telephone network to one of your numbers (an "inbound" message) or out - a message that was sent from one of your numbers to the telephone network (an "outbound" message) |
+| text | <code>String</code> | The message contents. |
+| media | <code>Array</code> | Json array containing list of media urls to be sent as content for an mms. |
+| state | <code>String</code> | Message state, values are received, queued, sending, sent, error |
+| time | <code>String</code> | The time the message resource was created (UTC, follows the ISO 8601 format). |
+| callbackUrl | <code>String</code> | The complete URL where the events related to the outgoing message will be sent. |
+| callbackTimeout | <code>Number</code> | Determine how long should the platform wait for callbackUrl's response before timing out. (milliseconds) |
+| fallbackUrl | <code>String</code> | The server URL used to send message events if the request to callbackUrl fails. |
+| size | <code>Number</code> | Used for pagination to indicate the size of each page requested for querying a list of messages. If no value is specified the default value is 25. (Maximum value 1000) |
+| tag | <code>String</code> | A string that will be included in the callback events of the message. |
+| receiptRequested | <code>String</code> | Requested receipt option for outbound messages: none, all, error Default is none. |
+| deliveryState | <code>String</code> | One of the message delivery states: waiting, delivered, not-delivered. |
+| deliveryCode | <code>Number</code> | Numeric value of deliver code. |
+| deliveryDescription | <code>String</code> | Message delivery description for the respective delivery code. |
 
 <a name="Recording"></a>
 
@@ -401,5 +438,5 @@ getNextLink
 
 | Param | Type | Description |
 | --- | --- | --- |
-| response | <code>Object</code> | A response object returned from calling 'client.makeRequest' |
+| response | <code>Object</code> | A headers object returned from calling 'client.makeRequest' (response.headers) |
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -105,7 +105,7 @@ var Application = function (client) {
 
 	/**
 	 * Make changes to an application.
-	 * @param  {String} applicationId The ID of the application to modify.
+	 * @param {String} applicationId The ID of the application to modify.
 	 * @param {Object} params Parameters for creating a new call
 	 * @param {String} [params.name] A name you choose for this application.
  	 * @param {String} [params.incomingCallUrl] A URL where call events will be sent for an inbound call.

--- a/lib/headerParsingLib.js
+++ b/lib/headerParsingLib.js
@@ -10,9 +10,13 @@ var getNextLink = function (headers) {
 	if (headers.link) {
 		var parsedHeader = parse(headers.link);
 		if (parsedHeader.next) {
-			delete parsedHeader.next.rel;
-			delete parsedHeader.next.url;
-			return parsedHeader.next;
+			var nextLink = {};
+			for (var elem in parsedHeader.next) {
+				if (elem !== "rel" && elem !== "url") {
+					nextLink[elem] = parsedHeader.next[elem];
+				}
+			}
+			return nextLink;
 		}
 	}
 	return null;

--- a/lib/headerParsingLib.js
+++ b/lib/headerParsingLib.js
@@ -1,4 +1,5 @@
 var parse = require("parse-link-header");
+var _ = require("lodash");
 
 /**
  * getNextLink
@@ -10,13 +11,7 @@ var getNextLink = function (headers) {
 	if (headers.link) {
 		var parsedHeader = parse(headers.link);
 		if (parsedHeader.next) {
-			var nextLink = {};
-			for (var elem in parsedHeader.next) {
-				if (elem !== "rel" && elem !== "url") {
-					nextLink[elem] = parsedHeader.next[elem];
-				}
-			}
-			return nextLink;
+			return _.omit(parsedHeader.next, [ "rel", "url" ]);
 		}
 	}
 	return null;

--- a/lib/headerParsingLib.js
+++ b/lib/headerParsingLib.js
@@ -1,20 +1,22 @@
-var parse = require("parse-link-header");
+var url = require("url");
+var querystring = require("querystring");
 
 /**
  * getNextLink
  * @function
- * @param {Object} response A response object returned from calling 'client.makeRequest'
+ * @param {Object} response A headers object returned from calling 'client.makeRequest' (response.headers)
  * @returns A parsed version of the link to the subsequent page, or null if no such page exists.
  */
 var getNextLink = function (headers) {
 	if (headers.link) {
-		var parsedUrls = parse(headers.link);
-		if (parsedUrls.next) {
-			var urlToReturn = {
-				size : parsedUrls.next.size,
-				page : parsedUrls.next.page
-			};
-			return urlToReturn;
+		var links = headers.link.split(",");
+		for (var elem in links) {
+			if (links[elem].indexOf("rel=\"next\"") !== -1) {
+				var linkRegex = /<(.*)>/;
+				var link = linkRegex.exec(links[elem])[1];
+				var parsedUrl = url.parse(link);
+				return querystring.parse(parsedUrl.query);
+			}
 		}
 	}
 	return null;

--- a/lib/headerParsingLib.js
+++ b/lib/headerParsingLib.js
@@ -1,5 +1,4 @@
-var url = require("url");
-var querystring = require("querystring");
+var parse = require("parse-link-header");
 
 /**
  * getNextLink
@@ -9,14 +8,11 @@ var querystring = require("querystring");
  */
 var getNextLink = function (headers) {
 	if (headers.link) {
-		var links = headers.link.split(",");
-		for (var elem in links) {
-			if (links[elem].indexOf("rel=\"next\"") !== -1) {
-				var linkRegex = /<(.*)>/;
-				var link = linkRegex.exec(links[elem])[1];
-				var parsedUrl = url.parse(link);
-				return querystring.parse(parsedUrl.query);
-			}
+		var parsedHeader = parse(headers.link);
+		if (parsedHeader.next) {
+			delete parsedHeader.next.rel;
+			delete parsedHeader.next.url;
+			return parsedHeader.next;
 		}
 	}
 	return null;

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,5 +1,5 @@
-var url = require("url");
-var qs = require("qs");
+var getNextLink = require("./headerParsingLib").getNextLink;
+var Promise = require("bluebird");
 
 /**
  * SMS or MMS Message
@@ -63,10 +63,29 @@ var Message = function (client) {
 		.asCallback(callback);
 	};
 
-	// TODO: document param types
 	/**
 	 * Gets a list of messages
 	 * @param  {Object} params Search parameters
+	 * @param  {String} [params.from] The phone number to filter the messages that
+	 * came from (must be in E.164 format, like +19195551212).
+	 * @param  {String} [params.to] The phone number to filter the messages that was
+	 * sent to (must be in E.164 format, like +19195551212).
+	 * @param  {String} [params.fromDateTime] The starting date time to filter the
+	 * messages (must be in yyyy-MM-dd hh:mm:ss format, like 2014-05-25 12:00:00. You can suppress parts of
+	 * the date or time, like 2014-05-25, but the missing parameters will be filled with zeros).
+	 * @param  {String} [params.toDateTime] The ending date time to filter the messages
+	 * (must be in yyyy-MM-dd hh:mm:ss format, like 2014-05-25 12:00:00. You can suppress parts of the date
+	 * or time, like 2014-05-25, but the missing parameters will be filled with zeros)
+	 * @param  {Number} [params.size] Used for pagination to indicate the size of each page requested \
+	 * for querying a list of messages. If no value is specified the default value is 25. (Maximum value 1000)
+	 * @param  {String} [params.direction] 	Filter by direction of message, in - a message that came from the
+	 * telephone network to one of your numbers (an "inbound" message) or out - a message that was sent from
+	 * one of your numbers to the telephone network (an "outbound" message)
+	 * @param  {String} [params.state] The message state to filter. Values are: received, queued, sending, sent, error
+	 * @param  {String} [params.deliveryState] The message delivery state to filter.
+	 * Values are waiting, delivered, not-delivered
+	 * @param  {String} [params.sortOrder] How to sort the messages. Values are asc or desc
+	 * If no value is specified the default value is asc
 	 * @param  {Function} [callback] A callback for the list of messages
 	 * @return {Array} A promise for the list of messages
 	 */
@@ -79,17 +98,19 @@ var Message = function (client) {
 		})
 		.then(function (response) {
 			var messageListResponse = {
-				messages : response.body
+				messages    : response.body,
+				hasNextPage : false,
+				getNextPage : function (nextCallback) {
+					return Promise.reject("Next page does not exist.")
+					.asCallback(nextCallback);
+				}
 			};
-			if (response.headers.link) {
-				var linkRegex = /<(.*)>/;
-				var link = linkRegex.exec(response.headers.link)[1];
-				var parsedUrl = url.parse(link);
-				var queryString = qs.parse(parsedUrl.query);
-				messageListResponse.hasMore = true;
+			var nextLink = getNextLink(response.headers);
+			if (nextLink) {
+				messageListResponse.hasNextPage = true;
 				messageListResponse.getNextPage = function (nextCallback) {
-					return self.list(queryString, nextCallback);
-				};
+					return self.list(nextLink, nextCallback);
+				}
 			}
 			return messageListResponse;
 		})
@@ -99,4 +120,30 @@ var Message = function (client) {
 
 module.exports = Message;
 
-// TODO: Document MessageResponse object
+/**
+ * @class MessageResponse
+ * @type Object
+ * @property {String} id The unique ID of the message.
+ * @property {String} from The message sender's telephone number (or short code).
+ * @property {String} to Message recipient telephone number (or short code).
+ * @property {String} direction Direction of message, in - a message that came from
+ * the telephone network to one of your numbers (an "inbound" message) or out - a message
+ * that was sent from one of your numbers to the telephone network (an "outbound" message)
+ * @property {String} text The message contents.
+ * @property {Array} media Json array containing list of media urls to be sent as content for an mms.
+ * @property {String} state Message state, values are received, queued, sending, sent, error
+ * @property {String} time The time the message resource was created (UTC, follows the ISO 8601 format).
+ * @property {String} callbackUrl The complete URL where the events related to the outgoing message will be sent.
+ * @property {Number} callbackTimeout Determine how long should the platform wait for callbackUrl's response
+ * before timing out. (milliseconds)
+ * @property {String} fallbackUrl The server URL used to send message events if the request to callbackUrl fails.
+ * @property {Number} size Used for pagination to indicate the size of each page requested for
+ * querying a list of messages.
+ * If no value is specified the default value is 25. (Maximum value 1000)
+ * @property {String} tag A string that will be included in the callback events of the message.
+ * @property {String} receiptRequested Requested receipt option for outbound messages: none, all, error
+ * Default is none.
+ * @property {String} deliveryState One of the message delivery states: waiting, delivered, not-delivered.
+ * @property {Number} deliveryCode Numeric value of deliver code.
+ * @property {String} deliveryDescription Message delivery description for the respective delivery code.
+ */

--- a/lib/message.js
+++ b/lib/message.js
@@ -110,7 +110,7 @@ var Message = function (client) {
 				messageListResponse.hasNextPage = true;
 				messageListResponse.getNextPage = function (nextCallback) {
 					return self.list(nextLink, nextCallback);
-				}
+				};
 			}
 			return messageListResponse;
 		})

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/bandwidthcom/node-bandwidth",
   "dependencies": {
     "bluebird": "^3.3.4",
+    "lodash": "^4.13.1",
     "parse-link-header": "^0.4.1",
     "qs": "^6.1.0",
     "parse-link-header": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "jshint-stylish": "^2.1.0",
     "mocha": "^2.4.5",
     "nock": "^7.5.0",
-    "parse-link-header": "^0.4.1",
     "should": "4.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/bandwidthcom/node-bandwidth",
   "dependencies": {
     "bluebird": "^3.3.4",
+    "parse-link-header": "^0.4.1",
     "qs": "^6.1.0",
     "request": "^2.69.0"
   },

--- a/test/message-test.js
+++ b/test/message-test.js
@@ -195,8 +195,8 @@ describe("Message API", function () {
 				var messages = messageResponse.messages;
 				(messages[0] === undefined).should.be.true;
 
-				return messageResponse.getNextPage()
-			});
+				return messageResponse.getNextPage();
+			})
 			.catch(function (err) {
 				err.should.eql("Next page does not exist.");
 			});

--- a/test/message-test.js
+++ b/test/message-test.js
@@ -148,9 +148,10 @@ describe("Message API", function () {
 				.reply(200, messagesList, {
 					"link" : "<https://api.catapult.inetwork.com" +
 						"/v1/users/" + userId + "/messages?fromDateTime=" +
-						fromDateTime + "&" + "toDateTime=" + toDateTime + "&size=25>; rel=\"next\""
+						fromDateTime + "&" + "toDateTime=" + toDateTime + "&sortKeyLT=1>; rel=\"next\""
 				})
-				.get("/v1/users/" + userId + "/messages?fromDateTime=" + fromDateTime + "&" + "toDateTime=" + toDateTime + "&size=25")
+				.get("/v1/users/" + userId + "/messages?fromDateTime=" + fromDateTime +
+						"&" + "toDateTime=" + toDateTime + "&sortKeyLT=1")
 				.reply(200, messagesList);
 		});
 

--- a/test/message-test.js
+++ b/test/message-test.js
@@ -148,9 +148,9 @@ describe("Message API", function () {
 				.reply(200, messagesList, {
 					"link" : "<https://api.catapult.inetwork.com" +
 						"/v1/users/" + userId + "/messages?fromDateTime=" +
-						fromDateTime + "&" + "toDateTime=" + toDateTime + ">"
+						fromDateTime + "&" + "toDateTime=" + toDateTime + "&size=25>; rel=\"next\""
 				})
-				.get("/v1/users/" + userId + "/messages?fromDateTime=" + fromDateTime + "&" + "toDateTime=" + toDateTime)
+				.get("/v1/users/" + userId + "/messages?fromDateTime=" + fromDateTime + "&" + "toDateTime=" + toDateTime + "&size=25")
 				.reply(200, messagesList);
 		});
 
@@ -171,14 +171,19 @@ describe("Message API", function () {
 				messages[0].should.eql(messagesList[0]);
 				messages[1].should.eql(messagesList[1]);
 
-				messageResponse.getNextPage()
-				.then(function (otherMessageResponse) {
+				return messageResponse.getNextPage();
+			})
+			.then(function (otherMessageResponse) {
 
-					messages = otherMessageResponse.messages;
+				messages = otherMessageResponse.messages;
 
-					messages[0].should.eql(messagesList[0]);
-					messages[1].should.eql(messagesList[1]);
-				});
+				messages[0].should.eql(messagesList[0]);
+				messages[1].should.eql(messagesList[1]);
+
+				return otherMessageResponse.getNextPage();
+			})
+			.catch(function (err) {
+				err.should.eql("Next page does not exist.");
 			});
 		});
 	});

--- a/test/message-test.js
+++ b/test/message-test.js
@@ -196,7 +196,7 @@ describe("Message API", function () {
 				(messages[0] === undefined).should.be.true;
 
 				return messageResponse.getNextPage()
-			})
+			});
 			.catch(function (err) {
 				err.should.eql("Next page does not exist.");
 			});


### PR DESCRIPTION
This PR attempts to resolve some issues within message.js and headerParsingLib.js

When querying for a list of messages, a next link is returned regardless of whether or not the following page actually has messages. Messages are also different because they does not use a `page` field; rather, they use `sortKeyLT` to do the pagination managing. The current implementation of headerParsingLib expects there to be a `page` field - so I've rewritten that library to be more generic. To do this, I've replaced the previous header parsing dependency with two core node libraries, url and querystring. Using these libraries allows headerParsingLib.js to remain generic without any 'hacky' coding required.

Some messages tests have been rewritten and the message documentation has been updated as well.
