### PR TITLE
Add makeRequestNoUser function to client

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -28,8 +28,15 @@ var Client = function (config) {
 	}
 
 	function createRequestOptions (params) {
+		var url;
+		if (params.attachUserPath) {
+			url = config.baseUrl + apiVersionPath + usersPath + "/" + config.userId + "/" + params.path;
+		}
+		else {
+			url = config.baseUrl + apiVersionPath + "/" + params.path;
+		}
 		return {
-			url                : config.baseUrl + apiVersionPath + usersPath + "/" + config.userId + "/" + params.path,
+			url                : url,
 			headers            : {
 				"User-Agent" : getUserAgentHeader()
 			},
@@ -46,6 +53,15 @@ var Client = function (config) {
 	}
 
 	this.makeRequest = function (params) {
+		params.attachUserPath = true;
+		return request(createRequestOptions(params)).then(handleResponse);
+	};
+
+	// Needed for http://ap.bandwidth.com/docs/rest-api/available-numbers/
+	// and
+	// http://ap.bandwidth.com/docs/rest-api/numberinfo/
+	this.makeRequestNoUser = function (params) {
+		params.attachUserPath = false;
 		return request(createRequestOptions(params)).then(handleResponse);
 	};
 };

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -10,6 +10,25 @@ describe("Client", function () {
 		accountType : "pre-pay"
 	};
 
+	var availableNumbersResponse = [
+		{
+			number         : "+15555555555",
+			nationalNumber : "(555) 555-5555",
+			city           : "ALHAMBRA",
+			rateCenter     : "ALHAMBRA",
+			state          : "CA",
+			price          : "0.00"
+		},
+		{
+			number         : "+15555555556",
+			nationalNumber : "(555) 555-5556",
+			city           : "ALHAMBRA",
+			rateCenter     : "ALHAMBRA",
+			state          : "CA",
+			price          : "0.00"
+		}
+	];
+
 	before(function () {
 		nock.disableNetConnect();
 	});
@@ -137,6 +156,36 @@ describe("Client", function () {
 			}).catch(function (err) {
 				err.statusCode.should.equal(404);
 				err.message.should.equal("");
+			});
+		});
+	});
+
+	describe("when no user path is needed", function () {
+		var client;
+
+		before(function () {
+			client = new Client({
+				userId   : "fakeUserId",
+				apiToken : "fakeApiToken",
+				apiKey   : "fakeApiKey"
+			});
+
+			nock(baseUrl)
+				.persist()
+				.get("/v1/availableNumbers/local?state=CA")
+				.reply(200, availableNumbersResponse);
+		});
+
+		after(function () {
+			nock.cleanAll();
+		});
+
+		it("should make requests to the default baseUrl with no user path", function () {
+			return client.makeRequestNoUser({
+				path : "availableNumbers/local",
+				qs   : { state : "CA" }
+			}).then(function (res) {
+				res.body.should.eql(availableNumbersResponse);
 			});
 		});
 	});


### PR DESCRIPTION
There are 3 endpoints that don't use `user-id` in the request path
- [`GET/POST availableNumbers/local`](http://ap.bandwidth.com/docs/rest-api/available-numbers/)
- [`GET/POST availableNumbers/tollFree`](http://ap.bandwidth.com/docs/rest-api/available-numbers/)
- [`GET phoneNumbers/numberInfo/{number}`](http://ap.bandwidth.com/docs/rest-api/numberinfo/)

Instead of parsing and running logic there on the path, I just added another request method that sets a variable `attachUserPath` to `true / false` for the function `createRequestOptions`.

This made the most sense to me, I'm open to suggestions.
