### PR TITLE
FIxed issue with module parse-link-header

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "bluebird": "^3.3.4",
     "qs": "^6.1.0",
+    "parse-link-header": "^0.4.1",
     "request": "^2.69.0"
   },
   "devDependencies": {
@@ -39,7 +40,6 @@
     "jshint-stylish": "^2.1.0",
     "mocha": "^2.4.5",
     "nock": "^7.5.0",
-    "parse-link-header": "^0.4.1",
     "should": "4.3.0"
   }
 }


### PR DESCRIPTION
`parse-link-header` is required by lib, not only be dev environment
