### PR TITLE
Added optional encoding parameter to Media.download

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2460,7 +2460,7 @@ Catapult API Client
 * [Media](#Media)
     * [new Media()](#new_Media_new)
     * [.upload(name, data, contentType, [callback])](#Media+upload) ⇒ <code>Promise</code>
-    * [.download(name, [callback])](#Media+download) ⇒ <code>[DownloadMediaFileResponse](#DownloadMediaFileResponse)</code>
+    * [.download(name, encoding, [callback])](#Media+download) ⇒ <code>[DownloadMediaFileResponse](#DownloadMediaFileResponse)</code>
     * [.list([callback])](#Media+list) ⇒ <code>[Array.&lt;MediaFileResponse&gt;](#MediaFileResponse)</code>
     * [.delete(name, [callback])](#Media+delete) ⇒ <code>Promise</code>
 
@@ -2486,7 +2486,7 @@ Upload a media file
 
 <a name="Media+download"></a>
 
-### media.download(name, [callback]) ⇒ <code>[DownloadMediaFileResponse](#DownloadMediaFileResponse)</code>
+### media.download(name, encoding, [callback]) ⇒ <code>[DownloadMediaFileResponse](#DownloadMediaFileResponse)</code>
 Download a media file
 
 **Kind**: instance method of <code>[Media](#Media)</code>  
@@ -2495,6 +2495,7 @@ Download a media file
 | Param | Type | Description |
 | --- | --- | --- |
 | name | <code>String</code> | The name of downloaded file. |
+| encoding | <code>String</code> | Optional response content encoding type. |
 | [callback] | <code>function</code> | Callback for the operation |
 
 <a name="Media+list"></a>

--- a/lib/client.js
+++ b/lib/client.js
@@ -43,7 +43,8 @@ var Client = function (config) {
 			},
 			json               : true,
 			body               : params.body,
-			rejectUnauthorized : false // for some reason this is required for bootcamp ssl
+			rejectUnauthorized : false, // for some reason this is required for bootcamp ssl
+			encoding           : params.encoding || null,
 		};
 	}
 

--- a/lib/media.js
+++ b/lib/media.js
@@ -78,13 +78,19 @@ var Media = function (client) {
 	/**
 	 * Download a media file
 	 * @param {String} name The name of downloaded file.
+	 * @param {String} encoding Optional response content encoding type.
 	 * @param {Function} [callback] Callback for the operation
 	 * @return {DownloadMediaFileResponse} A promise for the operation
 	 */
-	this.download = function (name, callback) {
+	this.download = function (name, encoding, callback) {
+		if (!callback && typeof encoding === "function") {
+			callback = encoding;
+			encoding = null;
+		}
 		return client.makeRequest({
-			path   : "media/" + encodeURIComponent(name),
-			method : "GET"
+			path     : "media/" + encodeURIComponent(name),
+			method   : "GET",
+			encoding : encoding,
 		})
 		.then(function (response) {
 			return { contentType : response.headers["content-type"], content : response.body };


### PR DESCRIPTION
The npm `request` package defaults to encoding all responses as a string if an **encoding** parameter is not specified in the request options. When executing a request with contentType _image/*_ file, the encoding should be set to null, as to allow for a buffer to be returned in the response content. Currently this is not an option when calling Media.download, resulting in corrupt data when downloading an image.

This fix provides an optional `encoding` parameter to `Media.download`, allowing the user to specify an encoding type, otherwise it is set to null in the request.