### PR TITLE
Fix jsdoc typo

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2617,9 +2617,9 @@ This is much more performant than calling `send` multiple times.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | params | <code>Array</code> |  | An array of params objects, each of which represents a single text message. The returned array will be in the same order as this array, so you can iterate over it. |
-| [params.text] | <code>String</code> |  | The message text to send |
-| [params.from] | <code>String</code> |  | The message sender's telephone number (or short code) This must be a Catapult number that you own. |
-| [params.to] | <code>String</code> |  | Message recipient telephone number (or short code) |
+| params.text | <code>String</code> |  | The message text to send |
+| params.from | <code>String</code> |  | The message sender's telephone number (or short code) This must be a Catapult number that you own. |
+| params.to | <code>String</code> |  | Message recipient telephone number (or short code) |
 | [params.media] | <code>Array</code> |  | Json array containing list of media urls to be sent as content for an mms. Valid URLs are: https://api.catapult.inetwork.com/v1/users/<user-id>/media/ We also support media URLs that are external to Bandwidth API, http:// or https:// format: Example: http://customer-web-site.com/file.jpg |
 | [params.callbackUrl] | <code>String</code> |  | The complete URL where the events related to the outgoing message will be sent |
 | [params.callbackTimeout] | <code>Number</code> |  | Determine how long should the platform wait for callbackUrl's response before timing out (milliseconds) |

--- a/docs/api.md
+++ b/docs/api.md
@@ -2552,7 +2552,7 @@ Remove a media file
 * [Message](#Message)
     * [new Message(client)](#new_Message_new)
     * [.send(params, [callback])](#Message+send) ⇒ <code>[MessageResponse](#MessageResponse)</code>
-    * [.sendMultiple(params, The, The, [callback])](#Message+sendMultiple) ⇒ <code>[ExtendedMessageResponse](#ExtendedMessageResponse)</code>
+    * [.sendMultiple(params, [callback])](#Message+sendMultiple) ⇒ <code>[ExtendedMessageResponse](#ExtendedMessageResponse)</code>
     * [.get(messageId, [callback])](#Message+get) ⇒ <code>[MessageResponse](#MessageResponse)</code>
     * [.list(params, [callback])](#Message+list) ⇒ <code>[MessageListResponse](#MessageListResponse)</code>
 
@@ -2607,7 +2607,7 @@ client.Message.send({
 ```
 <a name="Message+sendMultiple"></a>
 
-### message.sendMultiple(params, The, The, [callback]) ⇒ <code>[ExtendedMessageResponse](#ExtendedMessageResponse)</code>
+### message.sendMultiple(params, [callback]) ⇒ <code>[ExtendedMessageResponse](#ExtendedMessageResponse)</code>
 Send multiple SMS or MMS messages with one API call.
 This is much more performant than calling `send` multiple times.
 
@@ -2617,12 +2617,12 @@ This is much more performant than calling `send` multiple times.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | params | <code>Array</code> |  | An array of params objects, each of which represents a single text message. The returned array will be in the same order as this array, so you can iterate over it. |
-| The | <code>params.text</code> |  | message text to send |
-| The | <code>params.from</code> |  | message sender"s telephone number (or short code) This must be a Catapult number that you own. |
+| [params.text] | <code>String</code> |  | The message text to send |
+| [params.from] | <code>String</code> |  | The message sender's telephone number (or short code) This must be a Catapult number that you own. |
 | [params.to] | <code>String</code> |  | Message recipient telephone number (or short code) |
 | [params.media] | <code>Array</code> |  | Json array containing list of media urls to be sent as content for an mms. Valid URLs are: https://api.catapult.inetwork.com/v1/users/<user-id>/media/ We also support media URLs that are external to Bandwidth API, http:// or https:// format: Example: http://customer-web-site.com/file.jpg |
 | [params.callbackUrl] | <code>String</code> |  | The complete URL where the events related to the outgoing message will be sent |
-| [params.callbackTimeout] | <code>Number</code> |  | Determine how long should the platform wait for callbackUrl"s response before timing out (milliseconds) |
+| [params.callbackTimeout] | <code>Number</code> |  | Determine how long should the platform wait for callbackUrl's response before timing out (milliseconds) |
 | [params.fallbackUrl] | <code>String</code> |  | The server URL used to send message events if the request to callbackUrl fails |
 | [params.tag] | <code>String</code> |  | A string that will be included in the callback events of the message |
 | [params.receiptRequested] | <code>String</code> | <code>none</code> | Requested receipt option for outbound messages: `none` `all` `error` |

--- a/lib/message.js
+++ b/lib/message.js
@@ -65,10 +65,10 @@ var Message = function (client) {
 	 * @param  {Array} params An array of params objects, each of which
 	 * represents a single text message. The returned array will be in
 	 * the same order as this array, so you can iterate over it.
-	 * @param {String} [params.text] The message text to send
-	 * @param {String} [params.from] The message sender's telephone number (or short code)
+	 * @param {String} params.text The message text to send
+	 * @param {String} params.from The message sender's telephone number (or short code)
 	 * This must be a Catapult number that you own.
-	 * @param  {String} [params.to] Message recipient telephone number (or short code)
+	 * @param  {String} params.to Message recipient telephone number (or short code)
 	 * @param  {Array} [params.media] Json array containing list of media urls to be sent as content for an mms.
 	 * Valid URLs are: https://api.catapult.inetwork.com/v1/users/<user-id>/media/
 	 * We also support media URLs that are external to Bandwidth API, http:// or https:// format:

--- a/lib/message.js
+++ b/lib/message.js
@@ -65,8 +65,8 @@ var Message = function (client) {
 	 * @param  {Array} params An array of params objects, each of which
 	 * represents a single text message. The returned array will be in
 	 * the same order as this array, so you can iterate over it.
-	 * @param  {params.text} The message text to send
-	 * @param  {params.from} The message sender"s telephone number (or short code)
+	 * @param {String} [params.text] The message text to send
+	 * @param {String} [params.from] The message sender's telephone number (or short code)
 	 * This must be a Catapult number that you own.
 	 * @param  {String} [params.to] Message recipient telephone number (or short code)
 	 * @param  {Array} [params.media] Json array containing list of media urls to be sent as content for an mms.
@@ -76,7 +76,7 @@ var Message = function (client) {
 	 * @param  {String} [params.callbackUrl] The complete URL where the events related to the
 	 * outgoing message will be sent
 	 * @param  {Number} [params.callbackTimeout] Determine how long should the platform wait for
-	 * callbackUrl"s response before timing out (milliseconds)
+	 * callbackUrl's response before timing out (milliseconds)
 	 * @param  {String} [params.fallbackUrl] The server URL used to send message events
 	 * if the request to callbackUrl fails
 	 * @param  {String} [params.tag] A string that will be included in the callback events of the message


### PR DESCRIPTION
I noticed a typo in the jsdoc that was causing the arguments for [`message.sendMultiple`](https://github.com/bandwidthcom/node-bandwidth/blob/master/docs/api.md#messagesendmultipleparams-the-the-callback--extendedmessageresponse) to render as `(params, The, The, [callback])` in `docs/api.md`. Fixing it seemed like the simplest way to describe the issue :)