### PR TITLE
update encoding for media to pull as buffer from request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+- '7'
+- '6'
 - '5'
 - '4'
 - '0.12'

--- a/README.md
+++ b/README.md
@@ -25,25 +25,26 @@ The Full API Reference is available either as an interactive site or as a single
 ## Supported Versions
 `node-bandwidth` should work on all versions of node newer than `0.10.*`. However, due to the rapid development in the Node and npm environment, we can only provide _support_ on [LTS versions of Node](https://github.com/nodejs/LTS)
 
-| Version | Support Level |
-|---------|---------------|
-| <0.10.* | Unsupported | 
-| 0.10.* | Supported |
-| 0.12.* | Supported |
-| >=4.0 <4.2 | Unsupported |
-| __>=4.2 <5.* (Node v4 argon LTS)__ | **Recommended** |
-| 5.* | Unsupported |
-| 6.* | Unsupported |
+| Version                        | Support Level   |
+|:-------------------------------|:----------------|
+| <0.10.*                        | Unsupported     |
+| 0.10.*                         | Supported       |
+| 0.12.*                         | Supported       |
+| >=4.0 <4.2                     | Unsupported     |
+| >=4.2 <5.* (Node v4 argon LTS) | Supported       |
+| 5.*                            | Unsupported     |
+| _6.9.4 (Node v6 Boron LTS)_    | **Recommended** |
+| 7.*                            | Unsupported     |
 
 ## Client initialization
 
 All interaction with the API is done through a `client` Object. The client constructor takes an Object containing configuration options. The following options are supported:
 
-| Field name  | Description           | Default value                       | Required |
-|-------------|-----------------------|-------------------------------------|----------|
+| Field name  | Description            | Default value                       | Required |
+|:------------|:-----------------------|:------------------------------------|:---------|
 | `userId`    | Your Bandwidth user ID | `undefined`                         | Yes      |
-| `apiToken`  | Your API token        | `undefined`                         | Yes      |
-| `apiSecret` | Your API secret       | `undefined`                         | Yes      |
+| `apiToken`  | Your API token         | `undefined`                         | Yes      |
+| `apiSecret` | Your API secret        | `undefined`                         | Yes      |
 | `baseUrl`   | The Bandwidth API URL  | `https://api.catapult.inetwork.com` | No       |
 
 To initialize the client object, provide your API credentials which can be found on your account page in [the portal](https://catapult.inetwork.com/pages/catapult.jsf).
@@ -96,122 +97,3 @@ client.Message.send({
 ## Providing feedback
 
 For current discussions on 2.0 please see the [2.0 issues section on GitHub](https://github.com/bandwidthcom/node-bandwidth/labels/2.0). To start a new topic on 2.0, please open an issue and use the `2.0` tag. Your feedback is greatly appreciated!
-
-## Rest API Coverage
-------------
-* [Account](http://ap.bandwidth.com/docs/rest-api/account/)
-    * [X] Information
-    * [X] Transactions
-* [Applications](http://ap.bandwidth.com/docs/rest-api/applications/)
-    * [X] List
-    * [X] Create
-    * [X] Get info
-    * [X] Update
-    * [X] Delete
-* [Available Numbers](http://ap.bandwidth.com/docs/rest-api/available-numbers/)
-    * [X] Search Local
-    * [X] Buy Local
-    * [X] Search Tollfree
-    * [X] Buy Tollfree
-* [Bridges](http://ap.bandwidth.com/docs/rest-api/bridges/)
-    * [X] List
-    * [X] Create
-    * [X] Get info
-    * [X] Update Calls
-    * [X] Play Audio
-        * [X] Speak Sentence
-        * [X] Play Audio File
-    * [X] Get Calls
-* [Calls](http://ap.bandwidth.com/docs/rest-api/calls/)
-    * [X] List all calls
-    * [X] Create
-    * [X] Get info
-    * [X] Update Status
-        * [X] Transfer
-        * [X] Answer
-        * [X] Hangup
-        * [X] Reject
-    * [X] Play Audio
-        * [X] Speak Sentence
-        * [X] Play Audio File
-    * [X] Send DTMF
-    * [X] Events
-        * [X] List
-        * [X] Get individual info
-    * [X] List Recordings
-    * [X] List Transciptions
-    * [X] Gather
-        * [X] Create Gather
-        * [X] Get Gather info
-        * [X] Update Gather
-* [Conferences](http://ap.bandwidth.com/docs/rest-api/conferences/)
-    * [X] Create conference
-    * [X] Get info for single conference
-    * [X] Play Audio
-        * [X] Speak Sentence
-        * [X] Play Audio File
-    * [X] Members
-        * [X] Add member
-        * [X] List members
-        * [X] Update members
-            * [X] Mute
-            * [X] Remove
-            * [X] Hold
-        * [X] Play Audio to single member
-            * [X] Speak Sentence
-            * [X] Play Audio File
-* [Domains](http://ap.bandwidth.com/docs/rest-api/domains/)
-    * [X] List all domains
-    * [X] create domain
-    * [X] Delete domain
-* [Endpoints](http://ap.bandwidth.com/docs/rest-api/endpoints/)
-    * [X] List all endpoints
-    * [X] Create Endpoint
-    * [X] Get Single Endpoint
-    * [X] Update Single Endpoint
-    * [X] Delete Single Endpoint
-    * [X] Create auth token
-* [Errors](http://ap.bandwidth.com/docs/rest-api/errors/)
-    * [X] Get all errors
-    * [X] Get info on Single Error
-* [Intelligence Services](http://ap.bandwidth.com/docs/rest-api/intelligenceservices/)
-    * [ ] Number Intelligence
-* [Media](http://ap.bandwidth.com/docs/rest-api/media/)
-    * [X] List all media
-    * [X] Upload media
-    * [X] Download single media file
-    * [X] Delete single media
-* [Messages](http://ap.bandwidth.com/docs/rest-api/messages/)
-    * [X] List all messages
-    * [X] Send Message
-    * [X] Get single message
-    * [X] [Batch Messages](http://ap.bandwidth.com/docs/rest-api/messages/#resourcePOSTv1usersuserIdmessages) (single request, multiple messages)
-* [Number Info](http://ap.bandwidth.com/docs/rest-api/numberinfo/)
-    * [X] Get number info
-* [Phone Numbers](http://ap.bandwidth.com/docs/rest-api/phonenumbers/)
-    * [X] List all phonenumbers
-    * [X] Get single phonenumber
-    * [X] Order singe number
-    * [X] Update single number
-    * [X] Delete number
-* [Recordings](http://ap.bandwidth.com/docs/rest-api/recordings/)
-    * [X] List all recordings
-    * [X] Get single recording info
-* [Transciptions](http://ap.bandwidth.com/docs/rest-api/recordingsidtranscriptions/)
-    * [X] Create
-    * [X] Get info for single transcrption
-    * [X] Get all transcrptions for a recording
-* [BXML](http://ap.bandwidth.com/docs/xml/)
-    * [X] Call
-    * [X] Conference
-    * [X] Gather
-    * [X] Hangup
-    * [X] Media
-    * [X] Pause
-    * [X] PlayAudio
-    * [X] Record
-    * [X] Reject
-    * [X] SendMessage
-    * [X] SpeakSentence
-    * [X] Transfer
-

--- a/docs/api.md
+++ b/docs/api.md
@@ -3421,7 +3421,7 @@ Used to direct call flow for multiple transfer
 
 | Param | Type | Description |
 | --- | --- | --- |
-| phoneNumber | <code>String</code> | The phone number to try a transfer |
+| phoneNumber | <code>String</code> | The phone number to try for a transfer |
 
 <a name="BXMLResponse+transfer"></a>
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -43,7 +43,8 @@ var Client = function (config) {
 			},
 			json               : true,
 			body               : params.body,
-			rejectUnauthorized : false // for some reason this is required for bootcamp ssl
+			rejectUnauthorized : false, // for some reason this is required for bootcamp ssl
+			encoding           : params.encoding || undefined
 		};
 	}
 

--- a/lib/media.js
+++ b/lib/media.js
@@ -83,8 +83,9 @@ var Media = function (client) {
 	 */
 	this.download = function (name, callback) {
 		return client.makeRequest({
-			path   : "media/" + encodeURIComponent(name),
-			method : "GET"
+			path     : "media/" + encodeURIComponent(name),
+			method   : "GET",
+			encoding : null
 		})
 		.then(function (response) {
 			return { contentType : response.headers["content-type"], content : response.body };


### PR DESCRIPTION
According to [docs](https://github.com/request/request#requestoptions-callback): 

`encoding` - Encoding to be used on setEncoding of response data. If null, the body is returned as a Buffer. Anything else (including the default value of undefined) will be passed as the encoding parameter to toString() (meaning this is effectively utf8 by default). (Note: if you expect binary data, you should set encoding: null.) - Encoding to be used on setEncoding of response data. If null, the body is returned as a Buffer. Anything else (including the default value of undefined) will be passed as the encoding parameter to toString() (meaning this is effectively utf8 by default). (Note: if you expect binary data, you should set encoding: null.)

It seems that since we have always used `undefined` (the default behavior), we should keep doing that.