### PR TITLE
Allow download to return a Buffer

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2636,7 +2636,7 @@ Catapult API Client
 * [Media](#Media)
     * [new Media()](#new_Media_new)
     * [.upload(name, data, contentType, [callback])](#Media+upload) ⇒ <code>Promise</code>
-    * [.download(name, [callback])](#Media+download) ⇒ <code>[DownloadMediaFileResponse](#DownloadMediaFileResponse)</code>
+    * [.download(name, [,encoding='binary'][callback])](#Media+download) ⇒ <code>[DownloadMediaFileResponse](#DownloadMediaFileResponse)</code>
     * [.list([callback])](#Media+list) ⇒ <code>[Array.&lt;MediaFileResponse&gt;](#MediaFileResponse)</code>
     * [.delete(name, [callback])](#Media+delete) ⇒ <code>Promise</code>
 
@@ -2662,7 +2662,7 @@ Upload a media file
 
 <a name="Media+download"></a>
 
-### media.download(name, [callback]) ⇒ <code>[DownloadMediaFileResponse](#DownloadMediaFileResponse)</code>
+### media.download(name, [,encoding][callback]) ⇒ <code>[DownloadMediaFileResponse](#DownloadMediaFileResponse)</code>
 Download a media file
 
 **Kind**: instance method of <code>[Media](#Media)</code>  
@@ -2671,6 +2671,7 @@ Download a media file
 | Param | Type | Description |
 | --- | --- | --- |
 | name | <code>String</code> | The name of downloaded file. |
+| [encoding] | <code>String</code> &#124; <code>null</code> &#124; <code>Function</code> | The encoding that will be passed onto makeRequest, if null content will be a Buffer. If function is passed, it will be the callback |
 | [callback] | <code>function</code> | Callback for the operation |
 
 <a name="Media+list"></a>

--- a/lib/client.js
+++ b/lib/client.js
@@ -54,7 +54,7 @@ var Client = function (config) {
 			json               : true,
 			body               : params.body,
 			rejectUnauthorized : false, // for some reason this is required for bootcamp ssl
-			encoding           : params.encoding || undefined
+			encoding           : params.encoding || params.encoding === null ? params.encoding : undefined
 		};
 	}
 

--- a/lib/media.js
+++ b/lib/media.js
@@ -78,14 +78,22 @@ var Media = function (client) {
 	/**
 	 * Download a media file
 	 * @param {String} name The name of downloaded file.
+	 * @param {String/null/Function} [encoding='binary'] The encoding that will be passed onto makeRequest,
+		if null content will be a Buffer.  If function is passed, it will be the callback
 	 * @param {Function} [callback] Callback for the operation
 	 * @return {DownloadMediaFileResponse} A promise for the operation
 	 */
-	this.download = function (name, callback) {
+	this.download = function (name, encoding, callback) {
+
+		if(typeof encoding === 'function') {
+			callback = encoding;
+			encoding = 'binary';
+		}
+
 		return client.makeRequest({
 			path     : "media/" + encodeURIComponent(name),
 			method   : "GET",
-			encoding : "binary"
+			encoding : encoding
 		})
 		.then(function (response) {
 			return { contentType : response.headers["content-type"], content : response.body };


### PR DESCRIPTION
Allow `Media.download` to return a `Buffer` instead of a `binary` encoded string. When working with files, it's better to have the raw buffer, which is faster and uses less memory.

Besides if you want to save the downloaded content to a file or push it to another server, you will have to convert back to buffer

`Buffer.from(response.content, 'binary')`

- [ ] This pull request contains 100% test coverage.
- [X] This pull request is completely documented. All available fields are listed in the docs with description.
- [ ] Each public facing function should include at least one @example in the jsdoc.
- [x] Run `npm test` before committing.