### PR TITLE
Better Support Transpiled ES6 Import/Export

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,10 @@ CatapultClient.UnexpectedResponseError = UnexpectedResponseError;
 CatapultClient.RateLimitError          = RateLimitError;
 CatapultClient.BXMLResponse            = BXMLResponse;
 
+// Allow modules transformed from ES6 import/export to reference 
+// this constructor as the default export.
+CatapultClient.default = CatapultClient;
+
 Object.keys(queries).forEach(function (type) {
 	CatapultClient[type] = queries[type];
 });


### PR DESCRIPTION
In CommonJS, `node-bandwidth` provides the `CatapultClient` as the *only* export of the module. This is convenient for integrators writing CommonJS modules. However, for users transpiling (with Babel, Typescript, or otherwise) from ES6 import/export to CommonJS, it becomes *exceptionally* hard to reference the constructor. Consumers are required to use transpilation features like `esModuleInterop` or `interopRequireDefault` to reference the constructor, complicating their build configs.

By adding a reference to `CatapultClient` on to `CatapultClient.default`, consumers may use ES6 syntax, without breaking backwards compatibility.

The following is now possible: 
```js
import Bandwidth, { UnexpectedResponseError, RateLimitError, BXMLResponse } from "node-bandwidth";

const client = new Bandwidth({
	userId    : "YOUR_USER_ID",
	apiToken  : "YOUR_API_TOKEN",
	apiSecret : "YOUR_API_SECRET"
});
```

> EDIT: Happy to do the tasks below once the maintainers express interest in this change!

Make sure you've checked off all these things before submitting:

- [ ] This pull request contains 100% test coverage.
- [ ] This pull request is completely documented. All available fields are listed in the docs with description.
- [ ] Each public facing function should include at least one @example in the jsdoc.
- [ ] Run `npm test` before committing.